### PR TITLE
fix : restrict camera functionality to facial recognition only [ MHWC - 216 ]

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/ui/register_patient_activity/patient_details/PatientDetailsFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/register_patient_activity/patient_details/PatientDetailsFragment.kt
@@ -175,9 +175,7 @@ class PatientDetailsFragment : Fragment() , NavigationAdapter {
     private val takePictureLauncher =
         registerForActivityResult(ActivityResultContracts.TakePicture()) { result: Boolean ->
             if (result) {
-                // Picture was taken successfully, update the ImageView with the captured image
-                Glide.with(this).load(photoURI).placeholder(R.drawable.ic_person).circleCrop()
-                    .into(binding.ivImgCapture)
+                // Do NOT show the captured image yet — wait for face detection to pass first
 
                 try {
                     // Initialize MediaPipe Face Detector
@@ -210,6 +208,7 @@ class PatientDetailsFragment : Fragment() , NavigationAdapter {
                     // Handle detection results
                     when {
                         detectionResult.detections().isEmpty() -> {
+                            // No face — keep the placeholder, show toast
                             Toast.makeText(requireContext(), getString(R.string.no_face_detected), Toast.LENGTH_SHORT).show()
                             binding.ivImgCapture.setImageResource(R.drawable.ic_person)
                             faceDetector.close()
@@ -220,6 +219,10 @@ class PatientDetailsFragment : Fragment() , NavigationAdapter {
                             faceDetector.close()
                         }
                         else -> {
+                            // Face found — now show the captured photo
+                            Glide.with(this).load(photoURI).placeholder(R.drawable.ic_person).circleCrop()
+                                .into(binding.ivImgCapture)
+
                             val detection = detectionResult.detections()[0]
                             val boundingBox = detection.boundingBox()
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: MHWC - 216
Restrict camera to facial recognition only by disabling object and text detection across Android devices

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
