### PR TITLE
fix : Frequency field text overlaps with the Dose field in the prescription [MHWC-225]

### DIFF
--- a/app/src/main/res/layout/pharmacist_list_item_view.xml
+++ b/app/src/main/res/layout/pharmacist_list_item_view.xml
@@ -103,7 +103,7 @@
 
           </LinearLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
-        <androidx.constraintlayout.widget.ConstraintLayout
+          <LinearLayout
             android:id="@+id/card_second_row"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -136,13 +136,12 @@
 
           </LinearLayout>
 
-          <LinearLayout
-              android:layout_width="0dp"
-              app:layout_constraintEnd_toEndOf="parent"
-              app:layout_constraintTop_toTopOf="parent"
-              android:layout_height="wrap_content"
-              android:layout_weight="2"
-              android:orientation="horizontal">
+              <LinearLayout
+                  android:layout_width="0dp"
+                  android:layout_height="wrap_content"
+                  android:layout_weight="2"
+                  android:orientation="horizontal"
+                  android:gravity="end">
 
             <TextView
                 android:id="@+id/dose_label"
@@ -159,7 +158,7 @@
                 android:layout_marginStart="8dp" />
 
           </LinearLayout>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          </LinearLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/card_third_row"


### PR DESCRIPTION
## 📋 Description

JIRA ID: mhwc-225

fix: frequency field text overlapping with dose field

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment and layout rendering in the pharmacist list item display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->