### PR TITLE
Fix: Prevent crash by moving Toast to main thread in UserRepo

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
@@ -220,18 +220,19 @@ class UserRepo @Inject constructor(
 
                 for (i in 0 until vanSpDetailsArray.length()) {
                     val vanSp = vanSpDetailsArray.getJSONObject(i)
+                    if (!vanSp.has("facilityID")) {
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, "Facility ID not found", Toast.LENGTH_LONG).show()
+                        }
+                        delay(3000)
+                        continue
+                    }
                     val vanId = vanSp.getInt("vanID")
                     user?.vanId = vanId
                     val servicePointId = vanSp.getInt("servicePointID")
                     user?.servicePointId = servicePointId
                     val servicePointName = vanSp.getString("servicePointName")
                     user?.servicePointName = servicePointName
-                    if (!vanSp.has("facilityID")) {
-                        withContext(Dispatchers.Main) {
-                            Toast.makeText(context, "Facility ID not found", Toast.LENGTH_LONG).show()
-                        }
-                        delay(3000)
-                    }
                     val facilityId = vanSp.getInt("facilityID")
                     user?.facilityID = facilityId
                     user?.parkingPlaceId = vanSp.getInt("parkingPlaceID")

--- a/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
@@ -217,16 +217,16 @@ class UserRepo @Inject constructor(
                 val responseJson = JSONObject(responseString)
                 val data = responseJson.getJSONObject("data")
                 val vanSpDetailsArray = data.getJSONArray("UserVanSpDetails")
+                var validEntryFound = false
+                var missingFacilityFound = false
 
                 for (i in 0 until vanSpDetailsArray.length()) {
                     val vanSp = vanSpDetailsArray.getJSONObject(i)
                     if (!vanSp.has("facilityID")) {
-                        withContext(Dispatchers.Main) {
-                            Toast.makeText(context, "Facility ID not found", Toast.LENGTH_LONG).show()
-                        }
-                        delay(3000)
+                        missingFacilityFound = true
                         continue
                     }
+                    validEntryFound = true
                     val vanId = vanSp.getInt("vanID")
                     user?.vanId = vanId
                     val servicePointId = vanSp.getInt("servicePointID")
@@ -238,7 +238,13 @@ class UserRepo @Inject constructor(
                     user?.parkingPlaceId = vanSp.getInt("parkingPlaceID")
 
                 }
-                true
+                if (missingFacilityFound) {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(context, "Facility ID not found", Toast.LENGTH_LONG).show()
+                    }
+                    delay(3000)
+                }
+                validEntryFound
             } else {
                 false
             }
@@ -331,10 +337,13 @@ class UserRepo @Inject constructor(
                     user?.serviceMapId = serviceMapId
                     TokenInsertTmcInterceptor.setToken(token)
                     preferenceDao.registerPrimaryApiToken(token)
-                    preferenceDao.registerUser(user!!)
-                    getUserVanSpDetails(context)
+                    if (!getUserVanSpDetails(context)) {
+                        user = null
+                        return@withContext
+                    }
                     getLocDetailsBasedOnSpIDAndPsmID()
                     getUserMasterVillage()
+                    preferenceDao.registerUser(user!!)
                 } else {
                     val errorMessage = responseBody.getString("errorMessage")
                     GlobalScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
@@ -227,7 +227,9 @@ class UserRepo @Inject constructor(
                     val servicePointName = vanSp.getString("servicePointName")
                     user?.servicePointName = servicePointName
                     if (!vanSp.has("facilityID")) {
-                        Toast.makeText(context, "Facility ID not found", Toast.LENGTH_LONG).show()
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, "Facility ID not found", Toast.LENGTH_LONG).show()
+                        }
                         delay(3000)
                     }
                     val facilityId = vanSp.getInt("facilityID")


### PR DESCRIPTION
## 📋 Description
This PR fixes a potential crash caused by displaying a Toast from a background thread (Dispatchers.IO) in UserRepo.kt.

Previously, a Toast message ("Facility ID not found") was triggered inside an IO coroutine, which can lead to CalledFromWrongThreadException since UI operations must run on the main thread.

The fix ensures that the Toast is executed on Dispatchers.Main, making it safe and compliant with Android threading rules.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

### Testing
Verified the login flow where the Toast is triggered
Confirmed that the Toast displays correctly without any crash
Ensured no impact on existing functionality
### Notes
This is a minimal and safe fix
Improves app stability by ensuring UI operations run on the main thread
Aligns with Android best practices for coroutine usage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "Facility ID not found" notification could fail to appear; it now reliably displays and pauses briefly before proceeding, preventing confusing silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->