### PR TITLE
Fix biometric re-login session restore and infant birth weight input behavior

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/configuration/ChildRegistrationDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/configuration/ChildRegistrationDataset.kt
@@ -127,7 +127,7 @@ class ChildRegistrationDataset(
         etMaxLength = 4,
         min = WEIGHT_MIN.toLong(),
         max = WEIGHT_MAX.toLong(),
-        etInputType = android.text.InputType.TYPE_CLASS_NUMBER,
+        etInputType = android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_VARIATION_NORMAL,
     )
 
     // Q7: Any congenital anomaly detected?

--- a/app/src/main/java/org/piramalswasthya/cho/configuration/Dataset.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/configuration/Dataset.kt
@@ -173,7 +173,7 @@ abstract class Dataset(context: Context, currentLanguage: Languages) {
             // mutated in place: DiffUtil's areContentsTheSame compares the same
             // FormElement reference on both sides, so the change is invisible
             // and the row stays visually stale. Force a rebind on this row.
-            if (errorStateChanged && updateIndex == -1) {
+            if (errorStateChanged && updateIndex == -1 && formElement?.inputType != InputType.EDIT_TEXT) {
                 forceRefreshId(formId)
             }
         } else {

--- a/app/src/main/java/org/piramalswasthya/cho/ui/login_activity/username/UsernameFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/login_activity/username/UsernameFragment.kt
@@ -67,6 +67,10 @@ class UsernameFragment() : Fragment() {
     private lateinit var hwcViewModel: HwcViewModel
     private var user: UserCache? = null
     private var isBiometric : Boolean = false
+    private var pendingUserName: String = ""
+    private var pendingPassword: String = ""
+    private var pendingRememberUsername: Boolean = false
+    private var pendingIsBiometric: Boolean = false
     private var _binding: FragmentUsernameBinding? = null
     private val binding: FragmentUsernameBinding
         get() = _binding!!
@@ -166,6 +170,7 @@ class UsernameFragment() : Fragment() {
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.getOutreach()
+        observeLoginState()
         activity?.onBackPressedDispatcher?.addCallback(viewLifecycleOwner, onBackPressedCallback)
         binding.etUsername .addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
@@ -302,135 +307,82 @@ class UsernameFragment() : Fragment() {
 }
 
     private fun loginHwc(userName: String,password: String, rememberUsername: Boolean, isBiometric: Boolean) {
-
+        pendingUserName = userName
+        pendingPassword = password
+        pendingRememberUsername = rememberUsername
+        pendingIsBiometric = isBiometric
         val timestamp = getTimestamp()
 
-        if (!isBiometric) {
-            // Normal login
-            lifecycleScope.launch {
-                hwcViewModel.authUser(
-                    userName,
-                    password,
-                    "HWC",
-                    null,
-                    timestamp,
-                    null,
-                    currentLocation?.latitude,
-                    currentLocation?.longitude,
-                    null,
-                    requireContext()
-                )
+        lifecycleScope.launch {
+            hwcViewModel.authUser(
+                userName,
+                password,
+                "HWC",
+                null,
+                timestamp,
+                null,
+                currentLocation?.latitude,
+                currentLocation?.longitude,
+                null,
+                requireContext()
+            )
+        }
+    }
 
-                hwcViewModel.state.observe(viewLifecycleOwner) { state ->
-                    when (state) {
-                        OutreachViewModel.State.SUCCESS -> {
+    private fun observeLoginState() {
+        hwcViewModel.state.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                OutreachViewModel.State.SUCCESS -> {
+                    if (pendingRememberUsername)
+                        hwcViewModel.rememberUser(pendingUserName, pendingPassword)
+                    else
+                        hwcViewModel.forgetUser()
 
-//                            val user = userDao.getLoggedInUser()
-
-                            if (rememberUsername)
-                                hwcViewModel.rememberUser(userName, password)
-                            else
-                                hwcViewModel.forgetUser()
-
-                            findNavController().navigate(
-                                UsernameFragmentDirections.actionSignInToHomeFromCho(true)
-                            )
-
-                            hwcViewModel.resetState()
-                            activity?.finish()
-                        }
-
-                        OutreachViewModel.State.ERROR_SERVER,
-                        OutreachViewModel.State.ERROR_NETWORK -> {
-                            Toast.makeText(requireContext(), getString(R.string.login_failed_toast), Toast.LENGTH_LONG).show()
-                            hwcViewModel.resetState()
-                        }
-
-                        OutreachViewModel.State.SAVING -> {
-                            Toast.makeText(requireContext(), getString(R.string.processing), Toast.LENGTH_SHORT).show()
-                        }
-                        OutreachViewModel.State.IDLE -> {
-                            // No-op
-                        }
-                        OutreachViewModel.State.LOADING -> {
-                            // No-op
-                        }
-                        OutreachViewModel.State.ERROR_INPUT -> {
-                            Toast.makeText(requireContext(), getString(R.string.invalid_input), Toast.LENGTH_SHORT).show()
-                            hwcViewModel.resetState()
-                        }
-                    }
-                }
-            }
-        } else {
-            // Biometric login
-            lifecycleScope.launch {
-                hwcViewModel.authUser(
-                    userName,
-                    password,
-                    "HWC",
-                    null,
-                    timestamp,
-                    null,
-                    currentLocation?.latitude,
-                    currentLocation?.longitude,
-                    null,
-                    requireContext()
-                )
-
-                hwcViewModel.state.observe(viewLifecycleOwner) { state ->
-                    when (state) {
-                        OutreachViewModel.State.SUCCESS -> {
-                            if (rememberUsername)
-                                hwcViewModel.rememberUser(userName, password)
-                            else
-                                hwcViewModel.forgetUser()
-
-                            lifecycleScope.launch {
-                                try {
-                                    hwcViewModel.setOutreachDetails(
-                                        "HWC",
-                                        null,
-                                        timestamp,
-                                        null,
-                                        currentLocation?.latitude,
-                                        currentLocation?.longitude,
-                                        null,
-                                        false
-                                    )
-                                } catch (_: Exception) {
-                                    // Continue into Home even if the audit write fails.
-                                }
-
-                                findNavController().navigate(
-                                    UsernameFragmentDirections.actionSignInToHomeFromCho(true)
+                    lifecycleScope.launch {
+                        if (pendingIsBiometric) {
+                            try {
+                                hwcViewModel.setOutreachDetails(
+                                    "HWC",
+                                    null,
+                                    getTimestamp(),
+                                    null,
+                                    currentLocation?.latitude,
+                                    currentLocation?.longitude,
+                                    null,
+                                    false
                                 )
-
-                                hwcViewModel.resetState()
-                                activity?.finish()
+                            } catch (_: Exception) {
+                                // Continue into Home even if the audit write fails.
                             }
                         }
 
-                        OutreachViewModel.State.ERROR_SERVER,
-                        OutreachViewModel.State.ERROR_NETWORK -> {
-                            Toast.makeText(requireContext(), "API Services Down", Toast.LENGTH_LONG).show()
-                            hwcViewModel.resetState()
-                        }
+                        findNavController().navigate(
+                            UsernameFragmentDirections.actionSignInToHomeFromCho(true)
+                        )
 
-                        OutreachViewModel.State.SAVING -> {
-                            Toast.makeText(requireContext(), getString(R.string.processing), Toast.LENGTH_SHORT).show()
-                        }
-                        OutreachViewModel.State.IDLE -> {
-                            // No-op
-                        }
-                        OutreachViewModel.State.LOADING -> {
-                            // No-op
-                        }
-                        OutreachViewModel.State.ERROR_INPUT -> {
-                            Toast.makeText(requireContext(), getString(R.string.invalid_input), Toast.LENGTH_SHORT).show()
-                            hwcViewModel.resetState()
-                        }
+                        hwcViewModel.resetState()
+                        activity?.finish()
                     }
+                }
+
+                OutreachViewModel.State.ERROR_SERVER,
+                OutreachViewModel.State.ERROR_NETWORK -> {
+                    Toast.makeText(requireContext(), getString(R.string.login_failed_toast), Toast.LENGTH_LONG).show()
+                    hwcViewModel.resetState()
+                }
+
+                OutreachViewModel.State.SAVING -> {
+                    Toast.makeText(requireContext(), getString(R.string.processing), Toast.LENGTH_SHORT).show()
+                }
+                OutreachViewModel.State.IDLE -> {
+                    // No-op
+                }
+                OutreachViewModel.State.LOADING -> {
+                    // No-op
+                }
+                OutreachViewModel.State.ERROR_INPUT -> {
+                    Toast.makeText(requireContext(), getString(R.string.invalid_input), Toast.LENGTH_SHORT).show()
+                    hwcViewModel.resetState()
                 }
             }
         }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/login_activity/username/UsernameFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/login_activity/username/UsernameFragment.kt
@@ -125,10 +125,12 @@ class UsernameFragment() : Fragment() {
                 super.onAuthenticationSucceeded(result)
                 isBiometric = true
                 getCurrentLocation()
-                tryAuthUser = true
+                tryAuthUser = false
                 val userName = binding.etUsername.text.toString()
                 val remember = binding.cbRemember.isChecked
-                loginHwc(userName, "", remember, true)
+                // Reuse the normal login path so the local logged-in user is restored
+                // before Home opens. That keeps downstream modules and the drawer in sync.
+                loginHwc(userName, user?.password ?: "", remember, true)
                 displayMessage("Authentication succeeded!")
             }
 
@@ -363,9 +365,9 @@ class UsernameFragment() : Fragment() {
         } else {
             // Biometric login
             lifecycleScope.launch {
-                val user = userDao.getLoggedInUser()
-
-                hwcViewModel.setOutreachDetails(
+                hwcViewModel.authUser(
+                    userName,
+                    password,
                     "HWC",
                     null,
                     timestamp,
@@ -373,15 +375,63 @@ class UsernameFragment() : Fragment() {
                     currentLocation?.latitude,
                     currentLocation?.longitude,
                     null,
-                    false
+                    requireContext()
                 )
 
-                findNavController().navigate(
-                    UsernameFragmentDirections.actionSignInToHomeFromCho(true)
-                )
+                hwcViewModel.state.observe(viewLifecycleOwner) { state ->
+                    when (state) {
+                        OutreachViewModel.State.SUCCESS -> {
+                            if (rememberUsername)
+                                hwcViewModel.rememberUser(userName, password)
+                            else
+                                hwcViewModel.forgetUser()
 
-                hwcViewModel.resetState()
-                activity?.finish()
+                            lifecycleScope.launch {
+                                try {
+                                    hwcViewModel.setOutreachDetails(
+                                        "HWC",
+                                        null,
+                                        timestamp,
+                                        null,
+                                        currentLocation?.latitude,
+                                        currentLocation?.longitude,
+                                        null,
+                                        false
+                                    )
+                                } catch (_: Exception) {
+                                    // Continue into Home even if the audit write fails.
+                                }
+
+                                findNavController().navigate(
+                                    UsernameFragmentDirections.actionSignInToHomeFromCho(true)
+                                )
+
+                                hwcViewModel.resetState()
+                                activity?.finish()
+                            }
+                        }
+
+                        OutreachViewModel.State.ERROR_SERVER,
+                        OutreachViewModel.State.ERROR_NETWORK -> {
+                            Toast.makeText(requireContext(), "API Services Down", Toast.LENGTH_LONG).show()
+                            hwcViewModel.resetState()
+                        }
+
+                        OutreachViewModel.State.SAVING -> {
+                            Toast.makeText(requireContext(), getString(R.string.processing), Toast.LENGTH_SHORT).show()
+                        }
+                        OutreachViewModel.State.IDLE -> {
+                            // No-op
+                        }
+                        OutreachViewModel.State.LOADING -> {
+                            // No-op
+                        }
+                        OutreachViewModel.State.ERROR_INPUT -> {
+                            Toast.makeText(requireContext(), getString(R.string.invalid_input), Toast.LENGTH_SHORT).show()
+                            hwcViewModel.resetState()
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## 📋 Description

JIRA ID: MHWC-270

## 📋 Summary

- Restores the logged-in user state before navigating to Home after biometric re-entry, so RMNCH modules no longer see a timed-out session immediately after successful biometric login.
- Adds a controlled toast for biometric API/network failure and keeps the user on the Login screen when auth does not succeed.
- Fixes infant birth weight typing behavior by removing the extra forced refresh for edit-text validation-only updates, which was disrupting focus/cursor behavior.
- Aligns the infant birth weight field more closely with the existing ANC weight input behavior.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Test Plan

- Log out via the 5 PM auto-logout flow or simulate a logged-out state.
- Perform biometric login and confirm:
- Home opens only after auth succeeds.
- Drawer shows correct user name and user ID.
- Open RMNCH maternal health forms and confirm they no longer show “Session timed out” immediately after biometric login.
- Simulate biometric API/network failure and confirm:
- App stays on the Login screen.
- Toast API Services Down appears.
- Open RMNCH -> Maternal Health -> Infant Registration and enter invalid birth weight values.
- Confirm keyboard remains usable.
- Confirm cursor/focus stays in the field while typing and backspacing.
- Confirm digits enter in normal left-to-right order.
- Verify ANC Visits weight field still behaves as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced biometric authentication to automatically restore the last logged-out user's session

* **Bug Fixes**
  * Fixed birth weight input field to display proper numeric keyboard
  * Improved error messaging during login, including clearer notifications for server unavailability
  * Optimized form refresh behavior to prevent unnecessary updates during edit operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/HWC-Mobile-App/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->