### PR TITLE
Fixed the issue "Retested in v5.0.12 ,after transferring a new benefi…

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/model/MaternalHealth.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/model/MaternalHealth.kt
@@ -419,11 +419,15 @@ data class AbortionDomain(
     }
 
     /**
-     * Check if abortion form is filled (has abortion type and facility)
+     * Check if the dedicated abortion form has been submitted. abortionType and
+     * abortionFacility get set during the ANC visit when the pregnancy outcome
+     * is marked aborted, so they cannot indicate this form's submission state.
+     * methodOfTermination and terminationDoneBy are required fields on this
+     * form and are only written by PregnantWomanAncAbortionDataset.mapValues.
      */
     val isAbortionFormFilled: Boolean
-        get() = abortionRecord?.let { 
-            it.abortionType != null && it.abortionFacility != null 
+        get() = abortionRecord?.let {
+            it.methodOfTermination != null && it.terminationDoneBy != null
         } ?: false
 }
 


### PR DESCRIPTION

JIRA ID: MHWC-260

After transferring a new beneficiary from the ANC module to the Abortion List module, the "View" button (green) is displayed instead of the "Add" button (red). Due to this, the CAC form cannot be filled.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved validation of maternal health form submissions by refining how the system determines if an abortion form has been completely filled. The validation now checks more accurate fields to ensure all required information is properly recorded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/HWC-Mobile-App/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->