### PR TITLE
Bugs MHWC -300 fixes

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/adapter/SubCategoryAdapter.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/adapter/SubCategoryAdapter.kt
@@ -1,12 +1,29 @@
 package org.piramalswasthya.cho.adapter
 
 import android.content.Context
-import android.view.View
-import android.view.ViewGroup
 import android.widget.ArrayAdapter
-import android.widget.TextView
-import org.piramalswasthya.cho.model.SubVisitCategory
+import android.widget.Filter
 
-class SubCategoryAdapter(context: Context, resource: Int,textViewResourceId:Int,  subCats: List<String>) :
-        ArrayAdapter<String>(context, resource,textViewResourceId, subCats) {
+class SubCategoryAdapter(
+    context: Context,
+    resource: Int,
+    textViewResourceId: Int,
+    private val subCats: List<String>
+) : ArrayAdapter<String>(context, resource, textViewResourceId, subCats) {
+
+    override fun getFilter(): Filter = object : Filter() {
+        override fun performFiltering(constraint: CharSequence?): FilterResults {
+            // Sub Category / Reason for Visit are pickers, not search fields.
+            // Always return the full list so stale text (e.g. after navigating back)
+            // doesn't narrow the dropdown to only the already-selected item.
+            return FilterResults().apply {
+                values = subCats
+                count = subCats.size
+            }
+        }
+
+        override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
+            notifyDataSetChanged()
+        }
+    }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/fhir_visit_details/FragmentVisitDetail.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/fhir_visit_details/FragmentVisitDetail.kt
@@ -689,8 +689,15 @@ class FragmentVisitDetail : Fragment(), NavigationAdapter,
         binding.deliveryDate.setText("")
         if (binding.subCatInput.text.isNullOrBlank()) {
             setSubCategoryDropdown()
+        } else if (viewModel.selectedSubCat.isBlank()) {
+            // Belt-and-suspenders: if view-state restoration brought the field text back
+            // but the ViewModel state was cleared earlier in the lifecycle, rehydrate it.
+            viewModel.selectedSubCat = binding.subCatInput.text.toString()
         }
-        if (binding.reasonForVisitInput.text.isNullOrBlank() && viewModel.selectedSubCat.isNotBlank()) {
+        if (!binding.reasonForVisitInput.text.isNullOrBlank() && viewModel.selectedReasonForVisit.isBlank()) {
+            viewModel.selectedReasonForVisit = binding.reasonForVisitInput.text.toString()
+        }
+        if (viewModel.selectedSubCat.isNotBlank()) {
             setReasonForVisitDropdown(viewModel.selectedSubCat)
         }
     }
@@ -1211,7 +1218,11 @@ class FragmentVisitDetail : Fragment(), NavigationAdapter,
                 options
             )
         )
-        if (currentSubCat !in options) {
+        // Only clear when the field has a real value that's no longer valid.
+        // Treating empty text as "invalid" wipes selectedSubCat / selectedReasonForVisit
+        // during the onViewCreated pass that runs before Android's view-state restoration,
+        // which then leaves the reason-for-visit dropdown un-rehydrated on back-nav.
+        if (currentSubCat.isNotEmpty() && currentSubCat !in options) {
             binding.subCatInput.setText("", false)
             viewModel.selectedSubCat = ""
             binding.reasonForVisitInput.setText("", false)


### PR DESCRIPTION
JIRA ID: MHWC-300

When coming back to the Visit Details Filling page, not able to edit Sub Category and Reason for Visit(only after editing Duration, fields can be edited, the 2 fields depend upon the Duration field which is wrong

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data preservation when returning to visit detail screens—selected values are now retained.
  * Enhanced handling of invalid subcategory selections with stricter validation logic.

* **Refactor**
  * Optimized component architecture for subcategory selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->