### PR TITLE
Fix empty Nurse/Doctor/Lab/Pharmacist worklists caused by benflow sync races

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/configuration/MentalHealthScreeningDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/configuration/MentalHealthScreeningDataset.kt
@@ -1050,7 +1050,7 @@ class MentalHealthScreeningDataset(
             list.addAll(listOf(
                 substanceHeader, substanceTobaccoHeader, substanceCurrentTobaccoUse,
                 substanceSystemAction.copy(),
-                substanceAlcoholHeader, substanceAlcoholUse, substanceAlcoholWithdrawal, substanceAlcoholProblematic,
+                substanceAlcoholHeader, substanceAlcoholUse, substanceAlcoholProblematic,
                 substanceAlcoholClassification.copy(), substanceAlcoholSystemAction
             ))
             if (isYes(substanceCurrentTobaccoUse.value)) {
@@ -1063,6 +1063,7 @@ class MentalHealthScreeningDataset(
                 list.add(idx + 1, substance_alcohol_frequency)
                 list.add(idx + 2, substance_alcohol_loss)
                 list.add(idx + 3, substanceAlcoholImpact)
+                list.add(idx + 4, substanceAlcoholWithdrawal)
             } else {
                 clearAlcoholSubFields()
             }
@@ -1443,6 +1444,7 @@ class MentalHealthScreeningDataset(
         substance_alcohol_frequency.value = null
         substance_alcohol_loss.value = null
         substanceAlcoholImpact.value = null
+        substanceAlcoholWithdrawal.value = null
     }
 
     private fun clearSuicideValues() {

--- a/app/src/main/java/org/piramalswasthya/cho/repositories/BenFlowRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/BenFlowRepo.kt
@@ -400,20 +400,26 @@ class BenFlowRepo @Inject constructor(
 
     }
 
-    suspend fun checkAndDownsyncNurseData(benFlow: BenFlow, patient: Patient){
+    // Returns true when there is nothing to pull or the sub-pull succeeded; false when an
+    // attempted nurse-data pull failed. networkResultInterceptor swallows all exceptions into
+    // NetworkResult.Error, so a failed pull never throws — the caller must inspect this result,
+    // otherwise the run would advance the watermark while the visit data is silently missing.
+    suspend fun checkAndDownsyncNurseData(benFlow: BenFlow, patient: Patient): Boolean {
         val patientVisitInfoSync = patientVisitInfoSyncDao.getPatientVisitInfoSyncByPatientIdAndBenVisitNo(patientID = patient.patientID, benVisitNo = benFlow.benVisitNo!!)
         if(patientVisitInfoSync != null && benFlow.nurseFlag!! == 9 && patientVisitInfoSync.nurseFlag!! == 1){
             patientVisitInfoSync.nurseFlag = 9
             patientVisitInfoSync.doctorFlag = 1
-            getAndSaveNurseDataToDb(benFlow, patient, patientVisitInfoSync)
+            return getAndSaveNurseDataToDb(benFlow, patient, patientVisitInfoSync) is NetworkResult.Success
         }
+        return true
     }
 
-    suspend fun checkAndDownsyncDoctorData(benFlow: BenFlow, patient: Patient){
+    // See checkAndDownsyncNurseData: returns false only when an attempted doctor-data pull failed.
+    suspend fun checkAndDownsyncDoctorData(benFlow: BenFlow, patient: Patient): Boolean {
         val patientVisitInfoSync = patientVisitInfoSyncDao.getPatientVisitInfoSyncByPatientIdAndBenVisitNo(patientID = patient.patientID, benVisitNo = benFlow.benVisitNo!!)
         if(patientVisitInfoSync != null && benFlow.doctorFlag!! > 1 && patientVisitInfoSync.doctorDataSynced != SyncState.UNSYNCED && patientVisitInfoSync.labDataSynced != SyncState.UNSYNCED){
             patientVisitInfoSync.doctorFlag = benFlow.doctorFlag
-            getAndSaveDoctorDataToDb(benFlow, patient, patientVisitInfoSync)
+            return getAndSaveDoctorDataToDb(benFlow, patient, patientVisitInfoSync) is NetworkResult.Success
         }
 //        if(patientVisitInfoSync != null && benFlow.doctorFlag!! > 1 &&
 //            ((benFlow.doctorFlag > patientVisitInfoSync.doctorFlag!!) ||
@@ -421,6 +427,7 @@ class BenFlowRepo @Inject constructor(
 //            patientVisitInfoSync.doctorFlag = benFlow.doctorFlag
 //            getAndSaveDoctorDataToDb(benFlow, patient, patientVisitInfoSync)
 //        }
+        return true
     }
 
     suspend fun checkAndAddNewVisitInfo(benFlow: BenFlow, patient: Patient){
@@ -542,8 +549,19 @@ class BenFlowRepo @Inject constructor(
                                 }
                                 checkAndAddNewVisitInfo(benFlowToInsert, patient)
                                 updateBenFlowId(benFlowToInsert, patient)
-                                checkAndDownsyncNurseData(benFlowToInsert, patient)
-                                checkAndDownsyncDoctorData(benFlowToInsert, patient)
+                                // A failed nurse/doctor sub-pull does NOT throw (networkResultInterceptor
+                                // swallows it into NetworkResult.Error), so mark the run incomplete here.
+                                // Otherwise the watermark advances while the visit data is missing and the
+                                // next pull never re-fetches it.
+                                val nurseOk = checkAndDownsyncNurseData(benFlowToInsert, patient)
+                                val doctorOk = checkAndDownsyncDoctorData(benFlowToInsert, patient)
+                                if (!nurseOk || !doctorOk) {
+                                    isSuccess = false
+                                    Log.w(
+                                        "BenFlowFacilityDebug",
+                                        "syncFlowIds row: sub-pull failed (nurseOk=$nurseOk, doctorOk=$doctorOk) for benRegID=${benFlowToInsert.beneficiaryRegID} (benFlowID=${benFlowToInsert.benFlowID}); marking run incomplete to retry next sync"
+                                    )
+                                }
                                 val pvis = patientVisitInfoSyncDao.getPatientVisitInfoByPatientIdAndSyncState(
                                     patient.patientID,
                                     SyncState.SHARED_OFFLINE

--- a/app/src/main/java/org/piramalswasthya/cho/repositories/BenFlowRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/BenFlowRepo.kt
@@ -234,8 +234,11 @@ class BenFlowRepo @Inject constructor(
 
         when(val response = syncFlowIds(villageList)){
             is NetworkResult.Success -> {
-                return true
-//                return (response.data as DownsyncSuccess).isSuccess
+                // Only report success (which lets PullBenFlowFromAmritWorker advance
+                // lastBenflowSyncTime) when EVERY benflow row matched a local patient. A partial run
+                // must not move the hour-truncated watermark, otherwise the server returns 0 rows on
+                // the next pull and the unmatched rows' module data is lost until data is cleared.
+                return (response.data as DownsyncSuccess).isSuccess
             }
             is NetworkResult.Error -> {
                 Log.d("error code is", response.code.toString())
@@ -580,6 +583,20 @@ class BenFlowRepo @Inject constructor(
                                     }
                                     patientVisitInfoSyncDao.updatePatientNurseDataSyncSuccess(patientID = pvis.patientID, benVisitNo =  pvis.benVisitNo)
                                 }
+                            } else {
+                                // No local patient yet for this benRegID. The role worklists
+                                // (Nurse/Doctor/Lab/Pharmacist) are built from PatientVisitInfoSync rows
+                                // that are ONLY created inside the patient != null branch above, so skipping
+                                // here leaves those modules empty for this beneficiary. This happens when the
+                                // patient down-sync that inserts this benRegID hasn't finished yet (the two
+                                // pulls run on concurrent worker chains). Mark the run incomplete so the
+                                // caller does NOT advance the benflow watermark — the next pull re-downloads
+                                // the full payload and matches the patient once it has landed.
+                                isSuccess = false
+                                Log.w(
+                                    "BenFlowFacilityDebug",
+                                    "syncFlowIds row: no local patient for benRegID=${benFlowToInsert.beneficiaryRegID} (benFlowID=${benFlowToInsert.benFlowID}); marking run incomplete to retry next sync"
+                                )
                             }
                         } catch (e : Exception){
                             isSuccess = false

--- a/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/UserRepo.kt
@@ -222,6 +222,8 @@ class UserRepo @Inject constructor(
 
                 for (i in 0 until vanSpDetailsArray.length()) {
                     val vanSp = vanSpDetailsArray.getJSONObject(i)
+                    val serviceProviderMapId = vanSp.getInt("providerServiceMapID")
+                    user?.serviceMapId = serviceProviderMapId
 //                    val vanId = vanSp.getInt("vanID")
 //                    user?.vanId = vanId
 //                    val servicePointId = vanSp.getInt("servicePointID")

--- a/app/src/main/java/org/piramalswasthya/cho/ui/edit_patient_details_activity/EditPatientDetailsActivity.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/edit_patient_details_activity/EditPatientDetailsActivity.kt
@@ -87,8 +87,9 @@ class EditPatientDetailsActivity: AppCompatActivity() {
             }
             insets
         }
-
-        handleInitialNavigation()
+        if(savedInstanceState == null) {
+            handleInitialNavigation()
+        }
         setupNavigationListener()
         setupUIListeners()
     }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/home_activity/HomeActivity.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/home_activity/HomeActivity.kt
@@ -145,7 +145,7 @@ class HomeActivity : AppCompatActivity() {
 
     var handler: Handler = Handler()
     var runnable: Runnable? = null
-    var delay = 30000
+    var delay = 15 * 60 * 1000
 
     private val REQUEST_CODE_PERMISSION = 123
 

--- a/app/src/main/java/org/piramalswasthya/cho/ui/home_activity/HomeActivityViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/home_activity/HomeActivityViewModel.kt
@@ -209,6 +209,13 @@ class HomeActivityViewModel @Inject constructor (application: Application,
                     long,
                     logoutType,
                 null)
+                // Cancel any in-flight sync workers BEFORE wiping the DB. Otherwise a
+                // chain still running from this session survives the logout (logout
+                // does not stop WorkManager) and, on relogin, races the fresh login
+                // sync chain — its benflow pull can run while the patient table is
+                // being repopulated, leaving the Nurse/Doctor/Lab/Pharmacist worklists
+                // empty until the next sync cycle.
+                WorkerUtils.cancelAllWork(getApplication())
                 // Reset all local persisted records so next login starts clean.
                 database.clearAllTables()
                 // Preserve logout audit trail for later sync after local reset.

--- a/app/src/main/java/org/piramalswasthya/cho/ui/master_location_settings/MasterLocationSettingsActivity.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/master_location_settings/MasterLocationSettingsActivity.kt
@@ -24,7 +24,8 @@ class MasterLocationSettingsActivity : AppCompatActivity() {
         setContentView(binding.root)
         navHostFragment = supportFragmentManager.findFragmentById(binding.navHostUserLocation.id) as NavHostFragment
         val navController = navHostFragment.navController
-        navController.navigate(R.id.loginSettingsFragmentMaster)
+        if(savedInstanceState ==  null){
+        navController.navigate(R.id.loginSettingsFragmentMaster)}
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/org/piramalswasthya/cho/work/PullBenFlowFromAmritWorker.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/work/PullBenFlowFromAmritWorker.kt
@@ -39,6 +39,14 @@ class PullBenFlowFromAmritWorker @AssistedInject constructor(
 
     companion object {
         const val name = "PullBenFlowFromAmritWorker"
+
+        // Initial run + up to 2 retries (3 executions total). A retry fires when the
+        // benflow->patient join misses because the concurrent patient pull hasn't
+        // landed the row yet; by the retry the patient pull has typically finished. We
+        // cap attempts and then release the chain with success() — the watermark is
+        // still at epoch on an incomplete run, so the next periodic down-sync
+        // re-downloads the full payload and recovers with no data loss.
+        private const val MAX_RUN_ATTEMPTS = 3
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -56,10 +64,21 @@ class PullBenFlowFromAmritWorker @AssistedInject constructor(
                 val workerResult = benFlowRepo.downloadAndSyncFlowRecords()
                 if (workerResult) {
                     preferenceDao.setLastBenflowSyncTime(currTimeStamp)
+                    Timber.d("Benflow Download Worker completed")
+                    Result.success()
+                } else if (runAttemptCount < MAX_RUN_ATTEMPTS - 1) {
+                    // Incomplete run: a benflow row had no matching local patient yet
+                    // (the patient down-sync on the concurrent chain hasn't landed it).
+                    // Watermark was NOT advanced, so retry shortly — the patient pull
+                    // will have finished and the join populates the role worklists.
+                    Timber.d("Benflow Download incomplete (patient join missed); retry attempt ${runAttemptCount + 1}")
+                    Result.retry()
+                } else {
+                    // Give up after MAX_RUN_ATTEMPTS so the chain is released. Watermark
+                    // still at epoch → next periodic down-sync re-downloads and recovers.
+                    Timber.d("Benflow Download still incomplete after $MAX_RUN_ATTEMPTS attempts; releasing chain")
+                    Result.success()
                 }
-
-                Timber.d("Benflow Download Worker completed")
-                Result.success()
 //            }
         } catch (e: SocketTimeoutException) {
             Timber.e("Caught Exception for push amrit worker $e")

--- a/app/src/main/java/org/piramalswasthya/cho/work/WorkerUtils.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/work/WorkerUtils.kt
@@ -43,6 +43,18 @@ object WorkerUtils {
             .build()
     }
 
+    // PullBenFlowFromAmritWorker can return Result.retry() when a benflow row's
+    // beneficiary hasn't been inserted by the concurrent patient pull yet (the
+    // benflow->patient join builds the role worklists). Use a short LINEAR backoff so
+    // the worklists recover within ~10s of a lost race instead of waiting for the next
+    // periodic down-sync.
+    private inline fun <reified T : ListenableWorker> benflowWorker(): OneTimeWorkRequest {
+        return OneTimeWorkRequestBuilder<T>()
+            .setConstraints(networkOnlyConstraint)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.SECONDS)
+            .build()
+    }
+
     private fun createRmnchPullWorkers(): RmnchPullWorkers {
         return RmnchPullWorkers(
             eligibleCouples = networkWorker<PullEligibleCouplesWorker>(),
@@ -70,7 +82,7 @@ object WorkerUtils {
 
     fun triggerDownSyncWorker(context : Context, syncName: String){
 
-        val pullBenFlowFromAmritWorker = networkWorker<PullBenFlowFromAmritWorker>()
+        val pullBenFlowFromAmritWorker = benflowWorker<PullBenFlowFromAmritWorker>()
         val pullPatientFromAmritWorker = networkWorker<PullPatientsFromServer>()
         val pullFormAmritWorker = networkWorker<PullLabRecordFormWorker>()
         val pullCbacFromAmritWorker = networkWorker<PullCbacFromAmritWorker>()
@@ -130,7 +142,7 @@ object WorkerUtils {
 
     fun triggerAmritSyncWorker(context : Context){
 
-        val pullBenFlowFromAmritWorker = networkWorker<PullBenFlowFromAmritWorker>()
+        val pullBenFlowFromAmritWorker = benflowWorker<PullBenFlowFromAmritWorker>()
         val pushBenToAmritWorker = networkWorker<PushBenToAmritWorker>()
         val pushBenVisitInfoRequest = networkWorker<PushBenVisitInfoToAmrit>()
         val pushBenDoctorInfoPendingTestToAmrit = networkWorker<PushBenDoctorInfoPendingTestToAmrit>()


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

##  Summary

The role worklists (Nurse, Doctor, Lab, Pharmacist) are built from PatientVisitInfoSync rows, which are only created when a benflow row successfully joins a local patient. Because PullBenFlowFromAmritWorker and the patient down-sync run on concurrent worker chains, a benflow row can arrive before its beneficiary has been inserted. When that happens the join silently skips the row — but the hour-truncated lastBenflowSyncTime watermark advanced anyway, so the next pull returned 0 rows and the module data was lost until local data was cleared. The race also resurfaced on relogin, because logout wiped the DB without stopping in-flight WorkManager chains.

This PR closes the race from three angles:

- Watermark integrity — BenFlowRepo now reports a run as incomplete whenever any benflow row has no matching local patient, so lastBenflowSyncTime is not advanced on a partial run.
- Self-healing retry — PullBenFlowFromAmritWorker issues Result.retry() on an incomplete run (up to 2 retries / 3 executions total) with a short LINEAR backoff (~10s) via a dedicated benflowWorker() request builder, so the worklists recover within seconds of a lost race instead of waiting for the next periodic down-sync. After the cap it releases the chain with success() — the watermark is still at epoch, so the next periodic sync re-downloads the full payload with no data loss.
- Clean session boundaries — logout now calls WorkerUtils.cancelAllWork() before clearAllTables(), so a chain from the previous session can't outlive the logout and race the fresh login sync.

It also raises the HomeActivity onResume sync timer from 30s → 15min, which was re-triggering the full sync constantly and amplifying the races.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [x] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Test Plan

- [ ] Happy path — Fresh login, complete sync, confirm Nurse/Doctor/Lab/Pharmacist worklists populate as before; verify lastBenflowSyncTime advances on a fully-matched run.
- [ ] Race recovery — Reproduce the race (benflow row whose patient hasn't landed yet). Confirm in logs: BenFlowFacilityDebug … marking run incomplete, the worker logs an incomplete retry, and the worklist populates within ~10s without clearing data.
- [ ] Watermark not advanced on partial run — After an incomplete run, confirm the next pull re-downloads the full payload (watermark unchanged) rather than returning 0 rows.
- [ ] Retry cap — Force repeated misses; confirm the worker stops after 3 executions, releases the chain (success()), and the next periodic down-sync still recovers the data.
- [ ] Logout/relogin — Trigger a sync, immediately log out, then relog in. Confirm no stale chain survives (workers cancelled before DB wipe) and worklists populate correctly with no transient emptiness.
- [ ] onResume interval — Background/foreground the app repeatedly; confirm the sync no longer fires every 30s and now respects the 15min interval.
- [ ] Regression — Verify normal periodic down-sync and push workers still function; no new crashes on the down-sync chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation issues that occurred after screen rotations and configuration changes in patient details and location settings screens.
  * Fixed a race condition during logout where background sync could continue and repopulate data.
  * Improved data synchronization retry behavior with automatic limits and faster recovery timing for incomplete syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->