### PR TITLE
Defer per-beneficiary nurse/doctor case-record pull to end of sync chains

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/repositories/BenFlowRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/BenFlowRepo.kt
@@ -176,7 +176,7 @@ class BenFlowRepo @Inject constructor(
 
     }
 
-    suspend fun downloadAndSyncFlowRecords(): Boolean {
+    suspend fun downloadAndSyncFlowRecords(pullClinical: Boolean = true): Boolean {
 
         val user = userRepo.getLoggedInUser()
         val loggedInFacilityID = user?.facilityID
@@ -232,7 +232,7 @@ class BenFlowRepo @Inject constructor(
             else -> {}
         }
 
-        when(val response = syncFlowIds(villageList)){
+        when(val response = syncFlowIds(villageList, pullClinical)){
             is NetworkResult.Success -> {
                 // Only report success (which lets PullBenFlowFromAmritWorker advance
                 // lastBenflowSyncTime) when EVERY benflow row matched a local patient. A partial run
@@ -456,7 +456,7 @@ class BenFlowRepo @Inject constructor(
         benFlowDao.insertBenFlow(benFlow = benFlow)
     }
 
-    suspend fun syncFlowIds(villageList: VillageIdList): NetworkResult<NetworkResponse> {
+    suspend fun syncFlowIds(villageList: VillageIdList, pullClinical: Boolean = true): NetworkResult<NetworkResponse> {
         val loggedInUser = userRepo.getLoggedInUser()
 
         return networkResultInterceptor {
@@ -549,18 +549,23 @@ class BenFlowRepo @Inject constructor(
                                 }
                                 checkAndAddNewVisitInfo(benFlowToInsert, patient)
                                 updateBenFlowId(benFlowToInsert, patient)
-                                // A failed nurse/doctor sub-pull does NOT throw (networkResultInterceptor
-                                // swallows it into NetworkResult.Error), so mark the run incomplete here.
-                                // Otherwise the watermark advances while the visit data is missing and the
-                                // next pull never re-fetches it.
-                                val nurseOk = checkAndDownsyncNurseData(benFlowToInsert, patient)
-                                val doctorOk = checkAndDownsyncDoctorData(benFlowToInsert, patient)
-                                if (!nurseOk || !doctorOk) {
-                                    isSuccess = false
-                                    Log.w(
-                                        "BenFlowFacilityDebug",
-                                        "syncFlowIds row: sub-pull failed (nurseOk=$nurseOk, doctorOk=$doctorOk) for benRegID=${benFlowToInsert.beneficiaryRegID} (benFlowID=${benFlowToInsert.benFlowID}); marking run incomplete to retry next sync"
-                                    )
+                                // The per-beneficiary nurse/doctor case-record pull (2 API calls each)
+                                // is the slow part of the benflow downsync. It runs ONLY in the clinical
+                                // pass (PullClinicalRecordsWorker, last in the chain) so the role worklists
+                                // built above appear early and the RMNCH/CPHC pulls aren't blocked behind it.
+                                // A failed sub-pull does NOT throw (networkResultInterceptor swallows it into
+                                // NetworkResult.Error), so mark the run incomplete here; otherwise the watermark
+                                // advances while the visit data is missing and the next pull never re-fetches it.
+                                if (pullClinical) {
+                                    val nurseOk = checkAndDownsyncNurseData(benFlowToInsert, patient)
+                                    val doctorOk = checkAndDownsyncDoctorData(benFlowToInsert, patient)
+                                    if (!nurseOk || !doctorOk) {
+                                        isSuccess = false
+                                        Log.w(
+                                            "BenFlowFacilityDebug",
+                                            "syncFlowIds row: sub-pull failed (nurseOk=$nurseOk, doctorOk=$doctorOk) for benRegID=${benFlowToInsert.beneficiaryRegID} (benFlowID=${benFlowToInsert.benFlowID}); marking run incomplete to retry next sync"
+                                        )
+                                    }
                                 }
                                 val pvis = patientVisitInfoSyncDao.getPatientVisitInfoByPatientIdAndSyncState(
                                     patient.patientID,
@@ -626,7 +631,7 @@ class BenFlowRepo @Inject constructor(
                 onTokenExpired = {
                     val user = userRepo.getLoggedInUser()!!
                     userRepo.refreshTokenTmc(user.userName, user.password)
-                    syncFlowIds(villageList)
+                    syncFlowIds(villageList, pullClinical)
                 },
             )
         }

--- a/app/src/main/java/org/piramalswasthya/cho/work/PullBenFlowFromAmritWorker.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/work/PullBenFlowFromAmritWorker.kt
@@ -56,27 +56,28 @@ class PullBenFlowFromAmritWorker @AssistedInject constructor(
 
                 Log.d("Benflow In Progress", "Benflow In Progress")
 
-                val currentInstant = Instant.now()
-                val currentDateTime = LocalDateTime.ofInstant(currentInstant, ZoneId.of("Asia/Kolkata"))
-                val startOfHour = currentDateTime.withMinute(0).withSecond(0).withNano(0)
-                val currTimeStamp = startOfHour.atZone(ZoneId.of("Asia/Kolkata")).toInstant().toEpochMilli()
-
-                val workerResult = benFlowRepo.downloadAndSyncFlowRecords()
+                // Worklist-only pass: inserts benflow rows and builds the role worklists
+                // (PATIENT_VISIT_INFO_SYNC) so the Nurse/Doctor/Lab/Pharmacist lists appear early.
+                // The slow per-beneficiary nurse/doctor case-record pull (~2 API calls per
+                // beneficiary) AND the benflow watermark advance are deferred to
+                // PullClinicalRecordsWorker at the END of the chain, so the RMNCH/CPHC pulls are
+                // not blocked behind the per-beneficiary loop. Because the watermark is NOT
+                // advanced here, the same fresh payload remains available to the clinical worker.
+                val workerResult = benFlowRepo.downloadAndSyncFlowRecords(pullClinical = false)
                 if (workerResult) {
-                    preferenceDao.setLastBenflowSyncTime(currTimeStamp)
-                    Timber.d("Benflow Download Worker completed")
+                    Timber.d("Benflow worklist sync completed")
                     Result.success()
                 } else if (runAttemptCount < MAX_RUN_ATTEMPTS - 1) {
                     // Incomplete run: a benflow row had no matching local patient yet
                     // (the patient down-sync on the concurrent chain hasn't landed it).
-                    // Watermark was NOT advanced, so retry shortly — the patient pull
-                    // will have finished and the join populates the role worklists.
-                    Timber.d("Benflow Download incomplete (patient join missed); retry attempt ${runAttemptCount + 1}")
+                    // Retry shortly — the patient pull will have finished and the join
+                    // populates the role worklists.
+                    Timber.d("Benflow worklist incomplete (patient join missed); retry attempt ${runAttemptCount + 1}")
                     Result.retry()
                 } else {
-                    // Give up after MAX_RUN_ATTEMPTS so the chain is released. Watermark
-                    // still at epoch → next periodic down-sync re-downloads and recovers.
-                    Timber.d("Benflow Download still incomplete after $MAX_RUN_ATTEMPTS attempts; releasing chain")
+                    // Give up after MAX_RUN_ATTEMPTS so the chain is released. The clinical
+                    // worker at the end retries the join and only then advances the watermark.
+                    Timber.d("Benflow worklist still incomplete after $MAX_RUN_ATTEMPTS attempts; releasing chain")
                     Result.success()
                 }
 //            }

--- a/app/src/main/java/org/piramalswasthya/cho/work/PullCbacFromAmritWorker.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/work/PullCbacFromAmritWorker.kt
@@ -50,12 +50,13 @@ class PullCbacFromAmritWorker @AssistedInject constructor(
                 preferenceDao.setLastCbacSyncTime(currTimeStamp)
             }
 
-            val benflowResult = benFlowRepo.downloadAndSyncFlowRecords()
-            if (benflowResult) {
-                preferenceDao.setLastBenflowSyncTime(currTimeStamp)
-            }
+            // Worklist-only refresh (second chance for the benflow->patient join). The slow
+            // per-beneficiary nurse/doctor pull and the benflow watermark advance are deferred to
+            // PullClinicalRecordsWorker at the end of the chain so RMNCH/CPHC aren't blocked behind
+            // the per-beneficiary loop. The watermark is intentionally NOT advanced here.
+            benFlowRepo.downloadAndSyncFlowRecords(pullClinical = false)
 
-            Timber.d("Cbac + Benflow Download Worker completed")
+            Timber.d("Cbac + Benflow worklist download worker completed")
             Result.success()
 //            }
         } catch (e: SocketTimeoutException) {

--- a/app/src/main/java/org/piramalswasthya/cho/work/PullClinicalRecordsWorker.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/work/PullClinicalRecordsWorker.kt
@@ -1,0 +1,93 @@
+package org.piramalswasthya.cho.work
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import org.piramalswasthya.cho.database.shared_preferences.PreferenceDao
+import org.piramalswasthya.cho.network.interceptors.TokenInsertTmcInterceptor
+import org.piramalswasthya.cho.repositories.BenFlowRepo
+import timber.log.Timber
+import java.net.SocketTimeoutException
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * Pulls the per-beneficiary nurse (beneficiaryGeneralOPDNurseFormDataToApp) and doctor
+ * (getBenCaseRecordFromDoctorGeneralOPD) case records for the current benflow payload.
+ *
+ * This is the slow part of the benflow downsync — roughly 2 sequential API calls per
+ * beneficiary (e.g. ~600 calls for 300 beneficiaries on a fresh sync). It is enqueued as the
+ * LAST worker in the down-sync / amrit-sync chains so that:
+ *  - the role worklists (PATIENT_VISIT_INFO_SYNC), which are created early by the worklist-only
+ *    benflow pass in [org.piramalswasthya.sakhi.work.PullBenFlowFromAmritWorker], appear quickly, and
+ *  - the RMNCH and CPHC pulls are not blocked behind the per-beneficiary loop.
+ *
+ * The benflow watermark ([PreferenceDao.setLastBenflowSyncTime]) is advanced HERE, not in the
+ * worklist pass. The doctor pull condition is not idempotent across re-derivation, so it relies
+ * on the watermark to bound re-pulls; keeping the watermark un-advanced until this worker runs
+ * guarantees the same fresh, watermark-gated payload is still available to it.
+ */
+@HiltWorker
+class PullClinicalRecordsWorker @AssistedInject constructor(
+    @Assisted private val appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val preferenceDao: PreferenceDao,
+    private val benFlowRepo: BenFlowRepo
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        const val name = "PullClinicalRecordsWorker"
+
+        // Initial run + up to 2 retries (3 executions total). A retry fires when the
+        // benflow->patient join still misses; the watermark is only advanced on a fully
+        // matched run, so an incomplete run is recovered by the next periodic down-sync.
+        private const val MAX_RUN_ATTEMPTS = 3
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override suspend fun doWork(): Result {
+        init()
+        return try {
+            Log.d("ClinicalRecords In Progress", "ClinicalRecords In Progress")
+
+            val currentInstant = Instant.now()
+            val currentDateTime = LocalDateTime.ofInstant(currentInstant, ZoneId.of("Asia/Kolkata"))
+            val startOfHour = currentDateTime.withMinute(0).withSecond(0).withNano(0)
+            val currTimeStamp = startOfHour.atZone(ZoneId.of("Asia/Kolkata")).toInstant().toEpochMilli()
+
+            val workerResult = benFlowRepo.downloadAndSyncFlowRecords(pullClinical = true)
+            if (workerResult) {
+                preferenceDao.setLastBenflowSyncTime(currTimeStamp)
+                Timber.d("Clinical records download worker completed")
+                Result.success()
+            } else if (runAttemptCount < MAX_RUN_ATTEMPTS - 1) {
+                Timber.d("Clinical records download incomplete (patient join missed); retry attempt ${runAttemptCount + 1}")
+                Result.retry()
+            } else {
+                Timber.d("Clinical records download still incomplete after $MAX_RUN_ATTEMPTS attempts; releasing chain")
+                Result.success()
+            }
+        } catch (e: SocketTimeoutException) {
+            Timber.e("Caught Exception for clinical records worker $e")
+            Result.retry()
+        }
+    }
+
+    private fun init() {
+        if (TokenInsertTmcInterceptor.getToken() == "")
+            preferenceDao.getPrimaryApiToken()?.let {
+                TokenInsertTmcInterceptor.setToken(it)
+            }
+        if (TokenInsertTmcInterceptor.getJwt() == "")
+            preferenceDao.getJWTAmritToken()?.let {
+                TokenInsertTmcInterceptor.setJwt(it)
+            }
+    }
+}

--- a/app/src/main/java/org/piramalswasthya/cho/work/WorkerUtils.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/work/WorkerUtils.kt
@@ -83,6 +83,9 @@ object WorkerUtils {
     fun triggerDownSyncWorker(context : Context, syncName: String){
 
         val pullBenFlowFromAmritWorker = benflowWorker<PullBenFlowFromAmritWorker>()
+        // Deferred per-beneficiary nurse/doctor case-record pull (the slow part of the benflow
+        // downsync). Runs LAST so RMNCH/CPHC pulls aren't blocked behind the per-beneficiary loop.
+        val pullClinicalRecordsWorker = benflowWorker<PullClinicalRecordsWorker>()
         val pullPatientFromAmritWorker = networkWorker<PullPatientsFromServer>()
         val pullFormAmritWorker = networkWorker<PullLabRecordFormWorker>()
         val pullCbacFromAmritWorker = networkWorker<PullCbacFromAmritWorker>()
@@ -137,12 +140,18 @@ object WorkerUtils {
                 pullEarFromAmritWorker,pullOphthalmicFromAmritWorker, pullOralFromAmritWorker, pullPainAssessmentFromAmritWorker, pullPsychosocialCaregiverSupport, pullNoseFromAmritWorker, pullThroatFromAmritWorker,  pullElderlyFromAmritWorker,
                 pullMentalFromAmritWorker
             ))
+            // Per-beneficiary nurse/doctor pull runs last, after RMNCH/CPHC, and advances the
+            // benflow watermark.
+            .then(pullClinicalRecordsWorker)
             .enqueue()
     }
 
     fun triggerAmritSyncWorker(context : Context){
 
         val pullBenFlowFromAmritWorker = benflowWorker<PullBenFlowFromAmritWorker>()
+        // Deferred per-beneficiary nurse/doctor case-record pull (the slow part of the benflow
+        // downsync). Runs LAST so RMNCH/CPHC pulls aren't blocked behind the per-beneficiary loop.
+        val pullClinicalRecordsWorker = benflowWorker<PullClinicalRecordsWorker>()
         val pushBenToAmritWorker = networkWorker<PushBenToAmritWorker>()
         val pushBenVisitInfoRequest = networkWorker<PushBenVisitInfoToAmrit>()
         val pushBenDoctorInfoPendingTestToAmrit = networkWorker<PushBenDoctorInfoPendingTestToAmrit>()
@@ -256,6 +265,9 @@ object WorkerUtils {
                 pullEarFromAmritWorker, pullOphthalmicFromAmritWorker , pullOralFromAmritWorker, pullPainAssessmentFromAmritWorker, pullPsychosocialCaregiverSupport, pullNoseFromAmritWorker, pullThroatFromAmritWorker, pullElderlyFromAmritWorker,
                 pullMentalFromAmritWorker
             ))
+            // Per-beneficiary nurse/doctor pull runs last, after RMNCH/CPHC, and advances the
+            // benflow watermark.
+            .then(pullClinicalRecordsWorker)
 //           .then(pushLabDataToAmrit)
             .enqueue()
     }


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

The benflow down-sync did two jobs in one pass: it built the role worklists (PATIENT_VISIT_INFO_SYNC) and pulled each beneficiary's nurse/doctor case records(~2 sequential API calls per beneficiary — roughly 600 calls for 300 beneficiaries on a fresh sync). Because this ran early in the WorkManager chain, the slow per-beneficiary loop blocked the RMNCH and CPHC pulls behind it, delaying that module data.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured beneficiary data synchronization workflow to separate worklist updates from clinical records retrieval, enabling more efficient and flexible data synchronization scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->