### PR TITLE
Mental health dropdown value removed if age is less then 11 years

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/DropdownConst.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/DropdownConst.kt
@@ -87,7 +87,7 @@ class DropdownConst {
         )
 
         /** Sub categories available for all genders and age groups. */
-        val cphcSubCategoriesAllAges: List<String> = listOf(ent, ophthalmic, oral, mentalHealth)
+        val cphcSubCategoriesAllAges: List<String> = listOf(ent, ophthalmic, oral)
 
         val visualAcuityList = listOf("6/6", "6/9", "6/12", "6/18", "6/24", "6/36", "6/60", "<6/60")
         val visualImpairmentList = listOf("6/18", "6/24", "6/36", "6/60", "<6/60")

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/fhir_visit_details/FragmentVisitDetail.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/fhir_visit_details/FragmentVisitDetail.kt
@@ -311,6 +311,17 @@ class FragmentVisitDetail : Fragment(), NavigationAdapter,
         return (ageGap >= minAge)
     }
 
+    private fun ageCheckForMentalHealth(dob: Date?): Boolean {
+        if (dob == null) return false
+        val today = Calendar.getInstance()
+        val birth = Calendar.getInstance().apply { time = dob }
+        var ageYears = today.get(Calendar.YEAR) - birth.get(Calendar.YEAR)
+        if (today.get(Calendar.DAY_OF_YEAR) < birth.get(Calendar.DAY_OF_YEAR)) {
+            ageYears--
+        }
+        return ageYears >= 11
+    }
+
     private fun setSubCategoryDropdown() {
         viewModel.selectedSubCat = ""
         binding.subCatInput.setText(viewModel.selectedSubCat, false)
@@ -901,6 +912,9 @@ class FragmentVisitDetail : Fragment(), NavigationAdapter,
     private fun resolveCphcSubCategoryOptions(): List<String> {
         val options = DropdownConst.cphcSubCategoriesAllAges.toMutableList()
         val dob = benVisitInfo.patient.dob
+        if (ageCheckForMentalHealth(dob)) {
+            options.add(DropdownConst.mentalHealth)
+        }
         if (ageCheckForNCD(dob)) {
             options.add(DropdownConst.ncd)
         }
@@ -914,6 +928,14 @@ class FragmentVisitDetail : Fragment(), NavigationAdapter,
 
     private fun rebuildSubCategoryAdapter() {
         if (!::benVisitInfo.isInitialized) return
+        val selectedSubCat = viewModel.selectedSubCat.ifBlank {
+            binding.subCatInput.text?.toString().orEmpty()
+        }
+        if (selectedSubCat == DropdownConst.mentalHealth &&
+            !ageCheckForMentalHealth(benVisitInfo.patient.dob)
+        ) {
+            clearSubCategoryAndReasonForVisit()
+        }
         val options = resolveBaseSubCategoryOptions()
         binding.subCatInput.setAdapter(
             SubCategoryAdapter(


### PR DESCRIPTION
## 📋 Description

JIRA ID: MHWC-327

Please provide a summary of the change and the motivation behind it. Include relevant context and details.
Mental health dropdown value removed if age is less then 11 years.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mental health subcategory options now appear only for patients who meet the appropriate age criteria.

* **Bug Fixes**
  * Removed an inapplicable subcategory from the general age group options.
  * If a previously selected mental health option is no longer valid, the selection and related fields are now cleared automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->