### PR TITLE
Fix: RMNCH module — Delivery Outcome 'View' button on unfilled cards, read-only form, and   Abortion form load failure

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/database/room/dao/MaternalHealthDao.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/database/room/dao/MaternalHealthDao.kt
@@ -379,7 +379,7 @@ interface MaternalHealthDao {
     @Query("""
         SELECT DISTINCT do.patientID FROM DELIVERY_OUTCOME do
         INNER JOIN PATIENT p ON do.patientID = p.patientID
-        WHERE do.isActive = 1
+        WHERE do.isActive = 1 AND do.dateOfDelivery IS NOT NULL
         AND p.genderID = 2
         AND p.age BETWEEN 15 AND 49
         ORDER BY do.updatedDate DESC
@@ -392,7 +392,7 @@ interface MaternalHealthDao {
     @Query("""
         SELECT COUNT(DISTINCT do.patientID) FROM DELIVERY_OUTCOME do
         INNER JOIN PATIENT p ON do.patientID = p.patientID
-        WHERE do.isActive = 1
+        WHERE do.isActive = 1 AND do.dateOfDelivery IS NOT NULL
         AND p.genderID = 2
         AND p.age BETWEEN 15 AND 49
     """)

--- a/app/src/main/java/org/piramalswasthya/cho/database/room/dao/MaternalHealthDao.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/database/room/dao/MaternalHealthDao.kt
@@ -42,6 +42,9 @@ interface MaternalHealthDao {
     @Query("select * from pregnancy_anc where isActive = 1 and patientID = :patientID")
     suspend fun getAllActiveAncRecords(patientID: String): List<PregnantWomanAncCache>
 
+    @Query("select * from pregnancy_anc where patientID = :patientID")
+    suspend fun getAllAncRecords(patientID: String): List<PregnantWomanAncCache>
+
     @Query("select * from pregnancy_anc where isActive = 1 and patientID = :patientID and weight IS NOT NULL order by visitNumber")
     suspend fun getCompletedActiveAncRecords(patientID: String): List<PregnantWomanAncCache>
 

--- a/app/src/main/java/org/piramalswasthya/cho/repositories/MaternalHealthRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/repositories/MaternalHealthRepo.kt
@@ -104,6 +104,10 @@ class MaternalHealthRepo @Inject constructor(
          return maternalHealthDao.getAllActiveAncRecords(benId)
     }
 
+    suspend fun getAllAncRecords(benId: String): List<PregnantWomanAncCache> {
+        return maternalHealthDao.getAllAncRecords(benId)
+    }
+
     suspend fun getCompletedActiveAncRecords(benId: String): List<PregnantWomanAncCache> {
         return maternalHealthDao.getCompletedActiveAncRecords(benId)
     }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/maternal_health/delivery_outcome/form/DeliveryOutcomeFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/maternal_health/delivery_outcome/form/DeliveryOutcomeFormFragment.kt
@@ -181,7 +181,7 @@ class DeliveryOutcomeFormFragment : Fragment() {
 
     private fun onNextClicked() {
         val adapter = binding.form.rvInputForm.adapter as? FormInputAdapter ?: return
-        val invalidIndex = adapter.validateInput(resources)
+        val invalidIndex = adapter.validateInput(resources, binding.form.rvInputForm)
         if (invalidIndex == -1) {
             viewModel.saveForm()
         } else {

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/maternal_health/delivery_outcome/form/DeliveryOutcomeFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/maternal_health/delivery_outcome/form/DeliveryOutcomeFormViewModel.kt
@@ -112,7 +112,7 @@ class DeliveryOutcomeFormViewModel @Inject constructor(
                     _benAgeGender.value = patientAge
                     _caseId.value = caseId
 
-                    if (saved != null) {
+                    if (saved != null && saved.dateOfDelivery != null) {
                         deliveryOutcome = saved
                         _deliveryOutcomeId.value = saved.id
                         _recordExists.value = true
@@ -126,13 +126,14 @@ class DeliveryOutcomeFormViewModel @Inject constructor(
                             caseId = caseId
                         )
                     } else {
-                        deliveryOutcome = DeliveryOutcomeCache(
+                        deliveryOutcome = saved ?: DeliveryOutcomeCache(
                             patientID = patientID,
                             isActive = true,
                             createdBy = userName,
                             updatedBy = userName,
                             syncState = SyncState.UNSYNCED
                         )
+                        _deliveryOutcomeId.value = deliveryOutcome.id
                         _recordExists.value = false
                         // Use full setUpPage method to show ALL fields (both delivery details and mother condition)
                         dataset.setUpPage(

--- a/app/src/main/java/org/piramalswasthya/cho/ui/home/rmncha/maternal_health/AbortionFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/home/rmncha/maternal_health/AbortionFormViewModel.kt
@@ -104,8 +104,7 @@ class AbortionFormViewModel(
                     _benAgeGender.postValue("${patient.patient.age} ${patient.ageUnit?.name} | ${patient.gender?.genderName}")
                     Timber.d("AbortionForm load: patient ok")
 
-                    val allAnc = maternalHealthRepo.getAllActiveAncRecords(patientId) +
-                        listOfNotNull(maternalHealthRepo.getLastAnc(patientId))
+                    val allAnc = maternalHealthRepo.getAllAncRecords(patientId)
                     val aborted = allAnc
                         .distinctBy { it.id }
                         .filter { it.isAborted && it.abortionDate != null }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/home/rmncha/maternal_health/DeliveryOutcomeFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/home/rmncha/maternal_health/DeliveryOutcomeFormViewModel.kt
@@ -126,17 +126,18 @@ class DeliveryOutcomeFormViewModel @Inject constructor(
     }
 
     private suspend fun loadDeliveryOutcome(user: org.piramalswasthya.cho.model.UserDomain) {
-        deliveryOutcome = DeliveryOutcomeCache(
-            patientID = patientID,
-            syncState = SyncState.UNSYNCED,
-            createdBy = user.userName,
-            updatedBy = user.userName,
-            isActive = true
-        )
-        deliveryOutcomeRepo.getDeliveryOutcome(patientID)?.let {
-            deliveryOutcome = it
+        val saved = deliveryOutcomeRepo.getDeliveryOutcome(patientID)
+        if (saved != null && saved.dateOfDelivery != null) {
+            deliveryOutcome = saved
             _recordExists.value = true
-        } ?: run {
+        } else {
+            deliveryOutcome = saved ?: DeliveryOutcomeCache(
+                patientID = patientID,
+                syncState = SyncState.UNSYNCED,
+                createdBy = user.userName,
+                updatedBy = user.userName,
+                isActive = true
+            )
             _recordExists.value = false
         }
     }


### PR DESCRIPTION
## 📋 Description

JIRA ID: MHWC-335, MHWC-336

### Overview

  This PR fixes three related bugs in the RMNCH module affecting the Delivery Outcome and
  Abortion List sub-modules.
  ──────
  ### Bug 1: Delivery Outcome list showing "View" instead of "Register" for unfilled records

  File:  MaternalHealthDao.kt

  When an ANC visit is submitted with the woman marked as delivered, the app creates a
  placeholder  DELIVERY_OUTCOME  row with  dateOfDelivery = NULL . The Neonatal Outcome
  eligibility queries were treating these placeholder rows as fully filled records, causing the
  beneficiary card to show a View button instead of Register.

  Fix: Added  AND do.dateOfDelivery IS NOT NULL  filter to the relevant DAO queries so
  placeholder records are excluded from the filled set.
  ──────
  ### Bug 2: Delivery Outcome form opening in read-only mode with only a "Back" button

  Files:  DeliveryOutcomeFormViewModel.kt  (commons & home/rmncha),
  DeliveryOutcomeFormFragment.kt

  Two sub-issues caused this:

  • The  recordExists  check was returning  true  for any existing DB record, including
  placeholder rows (where  dateOfDelivery = NULL ), which locked the form in view-only mode.
  • The  validateInput()  call was not passing the  RecyclerView , so  EditText  values were
  never synced to the form model before validation — causing the Register button to silently
  fail even when the form appeared complete.

  Fix:

  • Updated  recordExists  to only return  true  when  dateOfDelivery != null , treating
  placeholder records as new/unfilled while preserving their DB  id  for correct upsert on save.
  • Passed  binding.form.rvInputForm  to  validateInput()  to ensure typed values are synced
  before submission.
  ──────
  ### Bug 3: Abortion form showing "No abortion record found" toast on clicking "Add"

  Files:  MaternalHealthDao.kt ,  MaternalHealthRepo.kt ,  AbortionFormViewModel.kt

  When a pregnancy is marked as aborted during an ANC visit, all ANC records for that pregnancy
  are deactivated ( isActive = 0 ). The Abortion form was querying only active ANC records, so
  it could never find the aborted record and would always show an error toast.

  Fix: Added a  getAllAncRecords()  query (fetching all records regardless of  isActive ) and
  updated  AbortionFormViewModel  to use it, ensuring the aborted ANC record is found correctly.
  ──────

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

### ℹ️ Testing

  • Deliver a woman via ANC → Verify Delivery Outcome card shows Register button
  • Click Register → Verify form is editable and submits successfully
  • Submit abortion in ANC → Verify Abortion List card shows Add → Click Add → Verify form loads
  correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading all ANC visit records for a beneficiary, improving access to complete maternal health history.

* **Bug Fixes**
  * Improved delivery outcome handling so existing records are reused only when delivery date data is present.
  * Tightened neonatal outcome eligibility checks to include only women with a recorded delivery date.
  * Updated form validation to better detect invalid inputs before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->