### PR TITLE
Blank visit record created when navigating back from Visit Details pa…

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/ui/ENT/EarDiagnosisFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ENT/EarDiagnosisFormFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
@@ -14,7 +14,8 @@ import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.databinding.FragmentEarDiagnosisFormBinding
 import org.piramalswasthya.cho.model.FormElement
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.DropdownConst
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 @AndroidEntryPoint
 class EarDiagnosisFormFragment :
@@ -24,6 +25,7 @@ class EarDiagnosisFormFragment :
     private val binding get() = _binding!!
 
     override val viewModel: EarDiagnosisFormViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
 
     // ── View references ───────────────────────────────────────────────────────
 
@@ -34,6 +36,8 @@ class EarDiagnosisFormFragment :
     override val ageGenderTextView: TextView get() = binding.tvAgeGender
     override val submitButton: View get() = binding.btnSubmit
     override val cancelButton: View get() = binding.btnCancel
+
+    override val persistOnNext: Boolean = false
 
     // ── Form-specific values ──────────────────────────────────────────────────
 
@@ -61,11 +65,8 @@ class EarDiagnosisFormFragment :
         _binding = null
     }
 
-    // Stamp Ear visit metadata onto MasterDb from arguments and navigate to the vitals screen.
-    override fun onSaveSuccess() {
-        WorkerUtils.earPushWorker(requireContext())
-        navigateToCphcVitalsAfterSave(
-            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.ear,
-        )
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
+        navigateToCphcVitalsAfterSave(subCategory = DropdownConst.ear)
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ENT/EarDiagnosisFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ENT/EarDiagnosisFormViewModel.kt
@@ -13,6 +13,8 @@ import org.piramalswasthya.cho.repositories.EarDiagnosisRepo
 import org.piramalswasthya.cho.repositories.PatientRepo
 import org.piramalswasthya.cho.repositories.UserRepo
 import org.piramalswasthya.cho.ui.commons.BaseFormViewModel
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
+import org.piramalswasthya.cho.work.WorkerUtils
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -79,5 +81,16 @@ class EarDiagnosisFormViewModel @Inject constructor(
             dataset.mapValues(assessmentCache, 1)
             earDiagnosisRepo.saveAssessment(assessmentCache)
         }
+    }
+
+    /** Maps form values and stages them for persist on Submit to Doctor (no Room write yet). */
+    fun stagePendingSave(pendingStore: PendingCphcFormViewModel) {
+        check(::assessmentCache.isInitialized) { "Assessment cache not initialized" }
+        dataset.mapValues(assessmentCache, 1)
+        val snapshot = assessmentCache.copy()
+        pendingStore.stage(
+            persist = { earDiagnosisRepo.saveAssessment(snapshot) },
+            enqueuePush = { WorkerUtils.earPushWorker(it) },
+        )
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ENT/NoseDiagnosisFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ENT/NoseDiagnosisFormFragment.kt
@@ -9,6 +9,7 @@ import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -20,8 +21,9 @@ import org.piramalswasthya.cho.adapter.FormInputAdapter
 import org.piramalswasthya.cho.databinding.FragmentNoseDiagnosisFormBinding
 import org.piramalswasthya.cho.ui.commons.CphcFormNavigation
 import org.piramalswasthya.cho.ui.commons.BaseFormViewModel
+import org.piramalswasthya.cho.ui.commons.DropdownConst
 import org.piramalswasthya.cho.ui.commons.NavigationAdapter
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 
 @AndroidEntryPoint
@@ -31,6 +33,7 @@ class NoseDiagnosisFormFragment : Fragment(), NavigationAdapter {
     private val binding get() = _binding!!
 
     private val viewModel: NoseDiagnosisFormViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -117,18 +120,10 @@ class NoseDiagnosisFormFragment : Fragment(), NavigationAdapter {
                 BaseFormViewModel.State.SAVE_SUCCESS -> {
                     binding.llContent.visibility = View.VISIBLE
                     binding.pbForm.visibility = View.GONE
-                    WorkerUtils.nosePushWorker(requireContext())
                     Toast.makeText(context, getString(R.string.nose_diagnosis_saved), Toast.LENGTH_LONG).show()
                     // Prevent re-delivery of SAVE_SUCCESS when returning from Vitals via back/cancel.
                     viewModel.resetState()
-                    findNavController().navigate(
-                        org.piramalswasthya.cho.R.id.customVitalsFragment,
-                        CphcFormNavigation.buildVitalsBundle(
-                            arguments = arguments,
-                            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.nose,
-                            reasonForVisit = org.piramalswasthya.cho.ui.commons.DropdownConst.nose,
-                        ),
-                    )
+                    navigateToVitals()
                 }
 
                 BaseFormViewModel.State.SAVE_FAILED -> {
@@ -160,10 +155,22 @@ class NoseDiagnosisFormFragment : Fragment(), NavigationAdapter {
 
         val result = adapter.validateInput(resources)
         if (result == -1) {
-            viewModel.saveForm()
+            viewModel.stagePendingSave(pendingCphcFormViewModel)
+            navigateToVitals()
         } else {
             binding.form.rvInputForm.scrollToPosition(result)
         }
+    }
+
+    private fun navigateToVitals() {
+        findNavController().navigate(
+            R.id.customVitalsFragment,
+            CphcFormNavigation.buildVitalsBundle(
+                arguments = arguments,
+                subCategory = DropdownConst.nose,
+                reasonForVisit = DropdownConst.nose,
+            ),
+        )
     }
 
     override fun onSubmitAction() {

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ENT/NoseDiagnosisFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ENT/NoseDiagnosisFormViewModel.kt
@@ -96,5 +96,15 @@ class NoseDiagnosisFormViewModel @Inject constructor(
             Timber.d("Nose Diagnosis saved successfully")
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::assessmentCache.isInitialized) { "Assessment cache not initialized" }
+        dataset.mapValues(assessmentCache, 1)
+        val snapshot = assessmentCache.copy()
+        pendingStore.stage(
+            persist = { noseDiagnosisRepo.saveAssessment(snapshot) },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.nosePushWorker(it) },
+        )
+    }
 }
 

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ENT/ThroatDiagnosisFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ENT/ThroatDiagnosisFormFragment.kt
@@ -6,8 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
@@ -15,12 +15,9 @@ import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.adapter.FormInputAdapter
 import org.piramalswasthya.cho.databinding.FragmentThroatDiagnosisFormBinding
 import org.piramalswasthya.cho.model.FormElement
-import org.piramalswasthya.cho.model.MasterDb
-import org.piramalswasthya.cho.model.VisitMasterDb
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
 import org.piramalswasthya.cho.ui.commons.DropdownConst
-import org.piramalswasthya.cho.work.WorkerUtils
-import androidx.navigation.fragment.findNavController
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 @AndroidEntryPoint
 class ThroatDiagnosisFormFragment :
@@ -50,6 +47,10 @@ class ThroatDiagnosisFormFragment :
         viewModel.updateListOnValueChanged(formId, index)
     override fun onSaveForm() = viewModel.saveForm()
     override fun getFragmentId(): Int = R.id.throatDiagnosisFormFragment
+
+    override val persistOnNext: Boolean = false
+
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
 
     // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -104,10 +105,8 @@ class ThroatDiagnosisFormFragment :
     }
 
     // Stamp Throat visit metadata onto MasterDb from arguments and navigate to vitals; replaces fresh MasterDb construction that lost chief-complaint data.
-    override fun onSaveSuccess() {
-        WorkerUtils.throatPushWorker(requireContext())
-        navigateToCphcVitalsAfterSave(
-            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.throat,
-        )
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
+        navigateToCphcVitalsAfterSave(subCategory = DropdownConst.throat)
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ENT/ThroatDiagnosisFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ENT/ThroatDiagnosisFormViewModel.kt
@@ -143,4 +143,14 @@ class ThroatDiagnosisFormViewModel @Inject constructor(
             throatDiagnosisRepo.saveAssessment(assessmentCache)
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::assessmentCache.isInitialized) { "Assessment cache not initialized" }
+        dataset.mapValues(assessmentCache, 1)
+        val snapshot = assessmentCache.copy()
+        pendingStore.stage(
+            persist = { throatDiagnosisRepo.saveAssessment(snapshot) },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.throatPushWorker(it) },
+        )
+    }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/BaseAssessmentFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/BaseAssessmentFormFragment.kt
@@ -62,6 +62,20 @@ abstract class BaseAssessmentFormFragment<VM : BaseFormViewModel> : Fragment(), 
     /** Triggers the ViewModel save. */
     protected abstract fun onSaveForm()
 
+    /**
+     * When false, Next validates and calls [onStageAndProceed] instead of persisting.
+     * CPHC forms defer Room/sync save until "Submit to Doctor" on vitals.
+     */
+    protected open val persistOnNext: Boolean = true
+
+    /**
+     * Called after successful validation when [persistOnNext] is false.
+     * Subclasses should stage form data and navigate without writing to Room.
+     */
+    protected open fun onStageAndProceed() {
+        error("Subclasses with persistOnNext=false must override onStageAndProceed()")
+    }
+
     // ── Back-press ────────────────────────────────────────────────────────────
 
     protected val onBackPressedCallback = object : OnBackPressedCallback(true) {
@@ -196,7 +210,11 @@ abstract class BaseAssessmentFormFragment<VM : BaseFormViewModel> : Fragment(), 
         val adapter = inputFormRecyclerView.adapter as? FormInputAdapter ?: return
         val result = adapter.validateInput(resources)
         if (result == -1) {
-            onSaveForm()
+            if (persistOnNext) {
+                onSaveForm()
+            } else {
+                onStageAndProceed()
+            }
         } else {
             val fieldName = adapter.currentList.getOrNull(result)?.title ?: getString(R.string.form_input_empty_error)
             Toast.makeText(

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/PendingCphcFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/PendingCphcFormViewModel.kt
@@ -1,0 +1,50 @@
+package org.piramalswasthya.cho.ui.commons
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Activity-scoped holder for CPHC assessment data collected on form "Next".
+ * Persistence and push sync run only when the visit is finally submitted
+ * (e.g. "Submit to Doctor" on vitals), not when navigating past the form.
+ */
+@HiltViewModel
+class PendingCphcFormViewModel @Inject constructor() : ViewModel() {
+
+    private var persistAction: (suspend () -> Unit)? = null
+    private var enqueuePush: ((Context) -> Unit)? = null
+
+    fun stage(persist: suspend () -> Unit, enqueuePush: (Context) -> Unit) {
+        persistAction = persist
+        this.enqueuePush = enqueuePush
+    }
+
+    fun hasPending(): Boolean = persistAction != null
+
+    suspend fun persistPending(context: Context) {
+        val persist = persistAction ?: return
+        val push = enqueuePush
+        try {
+            persist()
+            push?.invoke(context)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to persist pending CPHC form")
+            throw e
+        } finally {
+            clear()
+        }
+    }
+
+    fun clear() {
+        persistAction = null
+        enqueuePush = null
+    }
+
+    override fun onCleared() {
+        clear()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/fhir_patient_vitals/FhirVitalsFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/fhir_patient_vitals/FhirVitalsFragment.kt
@@ -12,8 +12,10 @@ import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,6 +36,7 @@ import org.piramalswasthya.cho.model.VisitDB
 import org.piramalswasthya.cho.model.VitalsMasterDb
 import org.piramalswasthya.cho.repositories.UserRepo
 import org.piramalswasthya.cho.ui.commons.NavigationAdapter
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 import org.piramalswasthya.cho.ui.edit_patient_details_activity.EditPatientDetailsViewModel
 import org.piramalswasthya.cho.utils.generateUuid
 import org.piramalswasthya.cho.utils.nullIfEmpty
@@ -62,6 +65,7 @@ class FhirVitalsFragment : Fragment(R.layout.fragment_vitals_custom), Navigation
 
 
     val viewModel: FhirVitalsViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
 
     var fragment: Fragment = this;
     @Inject
@@ -658,6 +662,20 @@ class FhirVitalsFragment : Fragment(R.layout.fragment_vitals_custom), Navigation
         }
     }
 
+    private suspend fun persistPendingCphcFormSuspending() {
+        if (!pendingCphcFormViewModel.hasPending()) return
+        try {
+            pendingCphcFormViewModel.persistPending(requireContext())
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to persist pending CPHC assessment on visit submit")
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.form_save_failed),
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
     override fun getFragmentId(): Int {
         return R.id.fragment_vitals_info;
     }
@@ -686,9 +704,12 @@ class FhirVitalsFragment : Fragment(R.layout.fragment_vitals_custom), Navigation
                 }
                 if (emptyFields.isEmpty()) {
                     setVitalsMasterData()
-                    findNavController().navigate(
-                        R.id.action_customVitalsFragment_to_caseRecordCustom, bundle
-                    )
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        persistPendingCphcFormSuspending()
+                        findNavController().navigate(
+                            R.id.action_customVitalsFragment_to_caseRecordCustom, bundle
+                        )
+                    }
                 } else {
                     val message: String = if (emptyFields.size == 1) {
                         "Please fill the ${emptyFields[0]}"
@@ -730,8 +751,11 @@ class FhirVitalsFragment : Fragment(R.layout.fragment_vitals_custom), Navigation
                         viewModel.isDataSaved.observe(viewLifecycleOwner) {
                             when (it!!) {
                                 true -> {
-                                    WorkerUtils.clinicalPushWorker(requireContext())
-                                    requireActivity().finish()
+                                    viewLifecycleOwner.lifecycleScope.launch {
+                                        persistPendingCphcFormSuspending()
+                                        WorkerUtils.clinicalPushWorker(requireContext())
+                                        requireActivity().finish()
+                                    }
                                 }
                                 else -> {}
                             }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/ElderlyHealthAssessmentFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/ElderlyHealthAssessmentFormFragment.kt
@@ -18,11 +18,15 @@ import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.adapter.FormInputAdapter
 import org.piramalswasthya.cho.databinding.FragmentElderlyHealthAssessmentFormBinding
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.flow.Flow
 import org.piramalswasthya.cho.model.FormElement
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.DropdownConst
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 
 @AndroidEntryPoint
@@ -32,6 +36,9 @@ class ElderlyHealthAssessmentFormFragment : BaseAssessmentFormFragment<ElderlyHe
     private val binding get() = _binding!!
 
     override val viewModel: ElderlyHealthAssessmentFormViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
+
+    override val persistOnNext: Boolean = false
 
     override val inputFormRecyclerView: RecyclerView get() = binding.form.rvInputForm
     override val contentLayout: View get() = binding.llContent
@@ -76,10 +83,8 @@ class ElderlyHealthAssessmentFormFragment : BaseAssessmentFormFragment<ElderlyHe
     }
 
     // Stamp Elderly Health Assessment metadata onto MasterDb from arguments and navigate to the vitals screen.
-    override fun onSaveSuccess() {
-        WorkerUtils.elderlyPushWorker(requireContext())
-        navigateToCphcVitalsAfterSave(
-            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.elderlyHealthAssessment,
-        )
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
+        navigateToCphcVitalsAfterSave(subCategory = DropdownConst.elderlyHealthAssessment)
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/ElderlyHealthAssessmentFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/ElderlyHealthAssessmentFormViewModel.kt
@@ -136,4 +136,14 @@ class ElderlyHealthAssessmentFormViewModel @Inject constructor(
             Timber.d("Elderly Health Assessment saved")
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::assessmentCache.isInitialized) { "Assessment cache not initialized" }
+        dataset.mapValues(assessmentCache, 1)
+        val snapshot = assessmentCache.copy()
+        pendingStore.stage(
+            persist = { elderlyHealthRepo.saveAssessment(snapshot) },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.elderlyPushWorker(it) },
+        )
+    }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PainAndSymptomAssessmentFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PainAndSymptomAssessmentFormFragment.kt
@@ -4,8 +4,8 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.View
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
@@ -13,8 +13,9 @@ import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.databinding.FragmentPainSymptomAssessmentFormBinding
 import org.piramalswasthya.cho.model.FormElement
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
+import org.piramalswasthya.cho.ui.commons.DropdownConst
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 import android.os.Bundle
-import org.piramalswasthya.cho.work.WorkerUtils
 
 @AndroidEntryPoint
 class PainAndSymptomAssessmentFormFragment :
@@ -24,6 +25,9 @@ class PainAndSymptomAssessmentFormFragment :
     private val binding get() = _binding!!
 
     override val viewModel: PainAndSymptomAssessmentFormViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
+
+    override val persistOnNext: Boolean = false
 
     // ── View references ───────────────────────────────────────────────────────
 
@@ -62,10 +66,8 @@ class PainAndSymptomAssessmentFormFragment :
     }
 
     // Stamp Pain & Symptom Assessment metadata onto MasterDb from arguments and navigate to the vitals screen.
-    override fun onSaveSuccess() {
-        WorkerUtils.painAssessmentPushWorker(requireContext())
-        navigateToCphcVitalsAfterSave(
-            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.persistentPain,
-        )
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
+        navigateToCphcVitalsAfterSave(subCategory = DropdownConst.persistentPain)
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PainAndSymptomAssessmentFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PainAndSymptomAssessmentFormViewModel.kt
@@ -75,4 +75,14 @@ class PainAndSymptomAssessmentFormViewModel @Inject constructor(
             painAssessmentRepo.saveAssessment(assessmentCache)
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::assessmentCache.isInitialized) { "Assessment cache not initialized" }
+        dataset.mapValues(assessmentCache, 1)
+        val snapshot = assessmentCache.copy()
+        pendingStore.stage(
+            persist = { painAssessmentRepo.saveAssessment(snapshot) },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.painAssessmentPushWorker(it) },
+        )
+    }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PsychosocialCaregiverSupportFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PsychosocialCaregiverSupportFormFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
@@ -14,7 +14,8 @@ import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.databinding.FragmentPsychosocialCaregiverSupportFormBinding
 import org.piramalswasthya.cho.model.FormElement
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.DropdownConst
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 @AndroidEntryPoint
 class PsychosocialCaregiverSupportFormFragment :
@@ -24,6 +25,9 @@ class PsychosocialCaregiverSupportFormFragment :
     private val binding get() = _binding!!
 
     override val viewModel: PsychosocialCaregiverSupportFormViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
+
+    override val persistOnNext: Boolean = false
 
     // ── View references ───────────────────────────────────────────────────────
 
@@ -86,10 +90,8 @@ class PsychosocialCaregiverSupportFormFragment :
     }
 
     // Stamp Psychosocial Caregiver Support metadata onto MasterDb from arguments and navigate to the vitals screen.
-    override fun onSaveSuccess() {
-        WorkerUtils.psychosocialCaregiverSupport(requireContext())
-        navigateToCphcVitalsAfterSave(
-            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.psychosocialCaregiverSupport,
-        )
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
+        navigateToCphcVitalsAfterSave(subCategory = DropdownConst.psychosocialCaregiverSupport)
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PsychosocialCaregiverSupportFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/elder_health/PsychosocialCaregiverSupportFormViewModel.kt
@@ -88,4 +88,14 @@ class PsychosocialCaregiverSupportFormViewModel @Inject constructor(
             psychosocialRepo.saveAssessment(assessmentCache)
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::assessmentCache.isInitialized) { "Assessment cache not initialized" }
+        dataset.mapValues(assessmentCache, 1)
+        val snapshot = assessmentCache.copy()
+        pendingStore.stage(
+            persist = { psychosocialRepo.saveAssessment(snapshot) },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.psychosocialCaregiverSupport(it) },
+        )
+    }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/mental_health/MentalHealthScreeningFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/mental_health/MentalHealthScreeningFormFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.lifecycle.lifecycleScope
@@ -19,7 +19,8 @@ import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.databinding.FragmentMentalHealthScreeningFormBinding
 import org.piramalswasthya.cho.model.FormElement
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.DropdownConst
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 @AndroidEntryPoint
 class MentalHealthScreeningFormFragment :
@@ -29,6 +30,9 @@ class MentalHealthScreeningFormFragment :
     private val binding get() = _binding!!
 
     override val viewModel: MentalHealthScreeningFormViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
+
+    override val persistOnNext: Boolean = false
 
     // ── View references ───────────────────────────────────────────────────────
 
@@ -96,11 +100,9 @@ class MentalHealthScreeningFormFragment :
     }
 
     // Stamp Mental Health Screening metadata onto MasterDb from arguments and navigate to the vitals screen.
-    override fun onSaveSuccess() {
-        WorkerUtils.mentalPushWorker(requireContext())
-        navigateToCphcVitalsAfterSave(
-            subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.mentalHealth,
-        )
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
+        navigateToCphcVitalsAfterSave(subCategory = DropdownConst.mentalHealth)
     }
 
     private fun observePhq9Alert() {

--- a/app/src/main/java/org/piramalswasthya/cho/ui/mental_health/MentalHealthScreeningFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/mental_health/MentalHealthScreeningFormViewModel.kt
@@ -122,4 +122,14 @@ class MentalHealthScreeningFormViewModel @Inject constructor(
             mentalHealthScreeningRepo.saveScreening(screeningCache)
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::screeningCache.isInitialized) { "Screening cache not initialized" }
+        dataset.mapValues(screeningCache, 1)
+        val snapshot = screeningCache.copy()
+        pendingStore.stage(
+            persist = { mentalHealthScreeningRepo.saveScreening(snapshot) },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.mentalPushWorker(it) },
+        )
+    }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ophthalmic_screening/OphthalmicScreeningFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ophthalmic_screening/OphthalmicScreeningFragment.kt
@@ -9,23 +9,27 @@ import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import android.widget.ScrollView
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.databinding.FragmentOphthalmicScreeningBinding
 import org.piramalswasthya.cho.ui.commons.CphcFormNavigation
 import org.piramalswasthya.cho.ui.commons.DropdownConst
 import android.app.AlertDialog
 import org.piramalswasthya.cho.ui.commons.NavigationAdapter
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 @AndroidEntryPoint
 class OphthalmicScreeningFragment : Fragment(), NavigationAdapter {
 
     private val viewModel: OphthalmicScreeningViewModel by viewModels()
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
     private lateinit var binding: FragmentOphthalmicScreeningBinding
     private val args: OphthalmicScreeningFragmentArgs by navArgs()
 
@@ -239,15 +243,18 @@ class OphthalmicScreeningFragment : Fragment(), NavigationAdapter {
         }
 
         binding.btnNext.isEnabled = false
-        viewModel.save {
-            Toast.makeText(requireContext(), getString(R.string.saved_successfully), Toast.LENGTH_SHORT).show()
-            WorkerUtils.ophthalmicPushWorker(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            val staged = viewModel.stagePendingSaveSuspending(pendingCphcFormViewModel)
+            if (!staged) {
+                binding.btnNext.isEnabled = true
+                return@launch
+            }
             val bundle = CphcFormNavigation.buildVitalsBundle(
                 arguments = arguments,
-                subCategory = org.piramalswasthya.cho.ui.commons.DropdownConst.ophthalmic,
+                subCategory = DropdownConst.ophthalmic,
                 reasonForVisit = args.reasonForVisit,
             )
-            findNavController().navigate(org.piramalswasthya.cho.R.id.customVitalsFragment, bundle)
+            findNavController().navigate(R.id.customVitalsFragment, bundle)
         }
     }
 

--- a/app/src/main/java/org/piramalswasthya/cho/ui/ophthalmic_screening/OphthalmicScreeningViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/ophthalmic_screening/OphthalmicScreeningViewModel.kt
@@ -696,67 +696,7 @@ class OphthalmicScreeningViewModel @Inject constructor(
         _saveError.value = false
         viewModelScope.launch {
             try {
-                val user = userRepo.getLoggedInUser()
-                val patientId = currentPatientId ?: run {
-                    Timber.e("Cannot save: patientId is null")
-                    return@launch
-                }
-                val benVisitNo = currentBenVisitNo ?: run {
-                    Timber.e("Cannot save: benVisitNo is null")
-                    return@launch
-                }
-
-                val currentVisit = _ophthalmicVisit.value ?: OphthalmicVisit(
-                    patientID = patientId,
-                    benVisitNo = benVisitNo,
-                    createdBy = user?.userName ?: "Unknown",
-                    createdDate = Date().time,
-                    updatedBy = user?.userName ?: "Unknown",
-                    updatedDate = Date().time,
-                    syncState = 0
-                )
-
-                var conditionsJson: String? = null
-                val conditions = _caseIdConditions.value
-                if (!conditions.isNullOrEmpty()) {
-                    try {
-                        conditionsJson = moshiAdapter.toJson(conditions)
-                    } catch (e: Exception) {
-                        Timber.e(e, "Error converting conditions to JSON")
-                    }
-                }
-
-                currentVisit.apply {
-                    isDiabetic = _isDiabetic.value
-                    screeningPerformed = _isScreeningPerformed.value
-                    visualAcuityChartUsed = _chartUsed.value
-                    distVARight = _distVARight.value
-                    distVALeft = _distVALeft.value
-                    nearVA = _nearVA.value
-                    caseIdConditions = conditionsJson
-                    cataractSymptoms = _cataractSymptoms.value
-                    glaucomaSymptoms = _glaucomaSymptoms.value
-                    diabeticRetinopathySymptoms = _drSymptoms.value
-                    presbyopiaSymptoms = _presbyopiaSymptoms.value
-                    trachomaStatus = _trachomaStatus.value
-                    cornealDiseaseType = _cornealDiseaseType.value
-                    vitaminADeficiency = _vitaminADeficiency.value
-
-                    val injuryTypesVal = _injuryTypes.value
-                    injuryType = if (!injuryTypesVal.isNullOrEmpty()) {
-                        try { moshiAdapter.toJson(injuryTypesVal) } catch (e: Exception) {
-                            Timber.e(e, "Error converting injuryTypes to JSON")
-                            null
-                        }
-                    } else null
-                    foreignBodyRemoval = _foreignBodyRemoval.value
-                    chemicalExposure = _chemicalExposure.value
-
-                    updatedBy = user?.userName ?: "Unknown"
-                    updatedDate = Date().time
-                    syncState = 0
-                }
-
+                val currentVisit = buildVisitForSave() ?: return@launch
                 ophthalmicRepository.saveOphthalmicVisit(currentVisit)
                 onSuccess()
             } catch (e: Exception) {
@@ -764,5 +704,90 @@ class OphthalmicScreeningViewModel @Inject constructor(
                 _saveError.value = true
             }
         }
+    }
+
+    /** Builds the visit from current UI state and stages it for persist on Submit to Doctor. */
+    suspend fun stagePendingSaveSuspending(
+        pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
+    ): Boolean {
+        return try {
+            val visit = buildVisitForSave() ?: return false
+            val snapshot = visit.copy()
+            pendingStore.stage(
+                persist = { ophthalmicRepository.saveOphthalmicVisit(snapshot) },
+                enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.ophthalmicPushWorker(it) },
+            )
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "Error staging ophthalmic visit")
+            _saveError.value = true
+            false
+        }
+    }
+
+    private suspend fun buildVisitForSave(): OphthalmicVisit? {
+        val user = userRepo.getLoggedInUser()
+        val patientId = currentPatientId ?: run {
+            Timber.e("Cannot save: patientId is null")
+            return null
+        }
+        val benVisitNo = currentBenVisitNo ?: run {
+            Timber.e("Cannot save: benVisitNo is null")
+            return null
+        }
+
+        val currentVisit = _ophthalmicVisit.value ?: OphthalmicVisit(
+            patientID = patientId,
+            benVisitNo = benVisitNo,
+            createdBy = user?.userName ?: "Unknown",
+            createdDate = Date().time,
+            updatedBy = user?.userName ?: "Unknown",
+            updatedDate = Date().time,
+            syncState = 0
+        )
+
+        var conditionsJson: String? = null
+        val conditions = _caseIdConditions.value
+        if (!conditions.isNullOrEmpty()) {
+            try {
+                conditionsJson = moshiAdapter.toJson(conditions)
+            } catch (e: Exception) {
+                Timber.e(e, "Error converting conditions to JSON")
+            }
+        }
+
+        currentVisit.apply {
+            isDiabetic = _isDiabetic.value
+            screeningPerformed = _isScreeningPerformed.value
+            visualAcuityChartUsed = _chartUsed.value
+            distVARight = _distVARight.value
+            distVALeft = _distVALeft.value
+            nearVA = _nearVA.value
+            caseIdConditions = conditionsJson
+            cataractSymptoms = _cataractSymptoms.value
+            glaucomaSymptoms = _glaucomaSymptoms.value
+            diabeticRetinopathySymptoms = _drSymptoms.value
+            presbyopiaSymptoms = _presbyopiaSymptoms.value
+            trachomaStatus = _trachomaStatus.value
+            cornealDiseaseType = _cornealDiseaseType.value
+            vitaminADeficiency = _vitaminADeficiency.value
+
+            val injuryTypesVal = _injuryTypes.value
+            injuryType = if (!injuryTypesVal.isNullOrEmpty()) {
+                try {
+                    moshiAdapter.toJson(injuryTypesVal)
+                } catch (e: Exception) {
+                    Timber.e(e, "Error converting injuryTypes to JSON")
+                    null
+                }
+            } else null
+            foreignBodyRemoval = _foreignBodyRemoval.value
+            chemicalExposure = _chemicalExposure.value
+
+            updatedBy = user?.userName ?: "Unknown"
+            updatedDate = Date().time
+            syncState = 0
+        }
+        return currentVisit
     }
 }

--- a/app/src/main/java/org/piramalswasthya/cho/ui/oral_health/OralHealthFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/oral_health/OralHealthFormFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
@@ -14,11 +14,9 @@ import kotlinx.coroutines.flow.Flow
 import org.piramalswasthya.cho.R
 import org.piramalswasthya.cho.databinding.FragmentOralHealthFormBinding
 import org.piramalswasthya.cho.model.FormElement
-import org.piramalswasthya.cho.model.MasterDb
-import org.piramalswasthya.cho.model.VisitMasterDb
 import org.piramalswasthya.cho.ui.commons.BaseAssessmentFormFragment
 import org.piramalswasthya.cho.ui.commons.DropdownConst
-import org.piramalswasthya.cho.work.WorkerUtils
+import org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel
 
 @AndroidEntryPoint
 class OralHealthFormFragment : BaseAssessmentFormFragment<OralHealthFormViewModel>() {
@@ -46,6 +44,10 @@ class OralHealthFormFragment : BaseAssessmentFormFragment<OralHealthFormViewMode
     override fun onSaveForm() = viewModel.saveForm()
     override fun getFragmentId(): Int = R.id.fragment_oral_health_form
 
+    override val persistOnNext: Boolean = false
+
+    private val pendingCphcFormViewModel: PendingCphcFormViewModel by activityViewModels()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -61,8 +63,8 @@ class OralHealthFormFragment : BaseAssessmentFormFragment<OralHealthFormViewMode
     }
 
     // Stamp Oral Health visit metadata onto MasterDb from arguments and navigate to vitals.
-    override fun onSaveSuccess() {
-        WorkerUtils.oralPushWorker(requireContext())
+    override fun onStageAndProceed() {
+        viewModel.stagePendingSave(pendingCphcFormViewModel)
         navigateToCphcVitalsAfterSave(
             subCategory = DropdownConst.oral,
             reasonForVisit = DropdownConst.dental,

--- a/app/src/main/java/org/piramalswasthya/cho/ui/oral_health/OralHealthFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/oral_health/OralHealthFormViewModel.kt
@@ -77,5 +77,22 @@ class OralHealthFormViewModel @Inject constructor(
             oralHealthRepo.save(oralHealthCache)
         }
     }
+
+    fun stagePendingSave(pendingStore: org.piramalswasthya.cho.ui.commons.PendingCphcFormViewModel) {
+        check(::oralHealthCache.isInitialized) { "Oral health cache not initialized" }
+        dataset.mapValues(oralHealthCache, 1)
+        val snapshot = oralHealthCache.copy()
+        pendingStore.stage(
+            persist = {
+                if (snapshot.oralHealthId == 0L) {
+                    val user = userRepo.getLoggedInUser()
+                    snapshot.createdDate = System.currentTimeMillis()
+                    snapshot.createdBy = user?.userName
+                }
+                oralHealthRepo.save(snapshot)
+            },
+            enqueuePush = { org.piramalswasthya.cho.work.WorkerUtils.oralPushWorker(it) },
+        )
+    }
 }
 


### PR DESCRIPTION

## 📋 Description

JIRA ID: MHWC-240

Blank visit record created when navigating back from Visit Details page without submission issue has been fixed.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deferred saving for ENT, elderly health, mental health, ophthalmic, oral health, and psychosocial assessments.
  * Assessment data is now retained while progressing to the vitals screen and finalized during CPHC submission.
  * Added improved handling for pending-save failures, including user-facing error feedback.
  * Standardized navigation and save progression across supported assessment forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->