### PR TITLE
 Resets the "Enter Template Name" input after a template is added or deleted

### DIFF
--- a/app/src/main/java/org/piramalswasthya/cho/ui/commons/case_record/CaseRecordCustom.kt
+++ b/app/src/main/java/org/piramalswasthya/cho/ui/commons/case_record/CaseRecordCustom.kt
@@ -1763,6 +1763,11 @@ class CaseRecordCustom : Fragment(R.layout.case_record_custom_layout), Navigatio
         binding.inputUseTempForFields.setAdapter(adapter)
     }
 
+    /** Resets the "Enter Template Name" input after a template is added or deleted. */
+    private fun clearTemplateNameField() {
+        binding.inputTestName.setText("")
+    }
+
     private lateinit var syncBottomSheet: TemplateListBottomSheetFragment
     private fun openBottomSheet(str: HashSet<String?>) {
         syncBottomSheet = TemplateListBottomSheetFragment(str, prescriptionTemplateRepo,
@@ -1773,6 +1778,7 @@ class CaseRecordCustom : Fragment(R.layout.case_record_custom_layout), Navigatio
                     if (binding.inputUseTempForFields.text?.toString() == string) {
                         binding.inputUseTempForFields.setText("", false)
                     }
+                    clearTemplateNameField()
                     string?.let {
                         viewModeltemplate.callMarkDel(it)
                     }
@@ -2712,12 +2718,13 @@ class CaseRecordCustom : Fragment(R.layout.case_record_custom_layout), Navigatio
                             Toast.LENGTH_SHORT
                         ).show()
                     }
-                    binding.saveTemplate.isEnabled = false
-                    binding.saveTemplate.alpha = 0.5f
                     // Immediately reflect the newly saved template in the dropdown.
                     // tempDB is keyed on userId (which doesn't change on insert), so we
                     // rebuild the adapter here just like the delete path does.
                     requireActivity().runOnUiThread {
+                        clearTemplateNameField()
+                        binding.saveTemplate.isEnabled = true
+                        binding.saveTemplate.alpha = 1.0f
                         uniqueTemplateNames.add(tempNameVal)
                         setTemplateDropdown(uniqueTemplateNames.filterNotNull())
                     }


### PR DESCRIPTION


JIRA ID: MHWC-237

 Resets the "Enter Template Name" input after a template is added or deleted

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template name fields are now cleared after saving or deleting a template.
  * The “Save Template” button is restored to its active state after a template is saved, allowing users to save another template immediately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->